### PR TITLE
Use template for Git tagging in CI pipeline

### DIFF
--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -47,15 +47,15 @@ stages:
               workingDirectory: $(Build.Repository.LocalPath)/app/stacks
           - script: |
               git tag -l | xargs git tag -d
-              git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" fetch --tags
+              git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" fetch --tags
 
               DATE=$(date +%Y-%m-%d)
-              TAG_NAME="infra_$(Build.BuildNumber)"
+              TAG_NAME="infra_environments_$(Build.BuildNumber)"
               TAG_MESSAGE="${DATE}"
 
-              EXISTING_TAGS=$(git -c http.extraheader="AUTHORIZATION: bearer $(system.accesstoken)" tag -l --points-at HEAD)
+              EXISTING_TAGS=$(git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" tag -l --points-at HEAD)
               echo "$EXISTING_TAGS" | while read tag ; do
-                if [[ $tag == *"infra_"* ]]; then
+                if [[ $tag == *"infra_environments"* ]]; then
                   echo "##vso[build.addbuildtag]$tag"
                   echo "Tag already set - skipping"
                   exit 2
@@ -67,6 +67,6 @@ stages:
               git config --global user.name 'Azure DevOps'
               git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
               git tag -a "${TAG_NAME}" -m "${TAG_MESSAGE}"
-              git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push origin "${TAG_NAME}"
+              git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" push origin "${TAG_NAME}"
             condition: or(contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
             displayName: Git Tag

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -48,29 +48,6 @@ stages:
               serviceConnection: Terraform Dev
               subscriptionId: $(SUBSCRIPTION_ID)
               workingDirectory: $(Build.Repository.LocalPath)/app/stacks
-          - script: |
-              git config --global user.name 'Azure DevOps'
-              git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
-
-              git tag -l | xargs git tag -d
-              git fetch --tags
-
-              DATE=$(date +%Y-%m-%d)
-              TAG_NAME="infra_environments_$(Build.BuildNumber)"
-              TAG_MESSAGE="${DATE}"
-
-              EXISTING_TAGS=$(git tag -l --points-at HEAD)
-              echo "$EXISTING_TAGS" | while read tag ; do
-                if [[ $tag == *"infra_environments"* ]]; then
-                  echo "##vso[build.addbuildtag]$tag"
-                  echo "Tag already set - skipping"
-                  exit 2
-                fi
-              done
-
-              echo "##vso[build.addbuildtag]$TAG_NAME"
-
-              git tag -a "${TAG_NAME}" -m "${TAG_MESSAGE}"
-              git push origin "${TAG_NAME}"
-#            condition: or(contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-            displayName: Git Tag
+          - template: steps/git_tagging.yml@templates
+            parameters:
+              tagPrefix: infrastructure-environments

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -46,6 +46,9 @@ stages:
               subscriptionId: $(SUBSCRIPTION_ID)
               workingDirectory: $(Build.Repository.LocalPath)/app/stacks
           - script: |
+              git config --global user.name 'Azure DevOps'
+              git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
+              
               git tag -l | xargs git tag -d
               git fetch --tags
 
@@ -64,8 +67,6 @@ stages:
 
               echo "##vso[build.addbuildtag]$TAG_NAME"
 
-              git config --global user.name 'Azure DevOps'
-              git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
               git tag -a "${TAG_NAME}" -m "${TAG_MESSAGE}"
               git push origin "${TAG_NAME}"
 #            condition: or(contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -27,6 +27,9 @@ stages:
       - job: Validate
         displayName: Validate Terraform
         steps:
+          - checkout: self
+            clean: true
+            persistCredentials: true
           - script: |
               brew install terragrunt
               brew install tflint
@@ -48,7 +51,7 @@ stages:
           - script: |
               git config --global user.name 'Azure DevOps'
               git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
-              
+
               git tag -l | xargs git tag -d
               git fetch --tags
 

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -47,13 +47,13 @@ stages:
               workingDirectory: $(Build.Repository.LocalPath)/app/stacks
           - script: |
               git tag -l | xargs git tag -d
-              git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" fetch --tags
+              git fetch --tags
 
               DATE=$(date +%Y-%m-%d)
               TAG_NAME="infra_environments_$(Build.BuildNumber)"
               TAG_MESSAGE="${DATE}"
 
-              EXISTING_TAGS=$(git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" tag -l --points-at HEAD)
+              EXISTING_TAGS=$(git tag -l --points-at HEAD)
               echo "$EXISTING_TAGS" | while read tag ; do
                 if [[ $tag == *"infra_environments"* ]]; then
                   echo "##vso[build.addbuildtag]$tag"
@@ -67,6 +67,6 @@ stages:
               git config --global user.name 'Azure DevOps'
               git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
               git tag -a "${TAG_NAME}" -m "${TAG_MESSAGE}"
-              git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" push origin "${TAG_NAME}"
+              git push origin "${TAG_NAME}"
 #            condition: or(contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
             displayName: Git Tag

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -68,5 +68,5 @@ stages:
               git config --global user.email 'azure-devops@planninginspectorate.gov.uk'
               git tag -a "${TAG_NAME}" -m "${TAG_MESSAGE}"
               git -c http.extraheader="AUTHORIZATION: Basic token:$(System.AccessToken)" push origin "${TAG_NAME}"
-            condition: or(contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+#            condition: or(contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
             displayName: Git Tag


### PR DESCRIPTION
- Use template for Git tagging and include explicit checkout step that persists Git credentials