### PR TITLE
Use wrapper template for CI pipeline

### DIFF
--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -4,6 +4,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
+      ref: feature/ci-stage-wrapper
 
 pool:
   vmImage: ubuntu-latest
@@ -11,34 +12,27 @@ pool:
 variables:
   - template: ./variables/dev.yml
 
-stages:
-  - stage: Validate
-    displayName: Validate Terraform
-    jobs:
-      - job: Validate
-        displayName: Validate Terraform
-        steps:
-          - checkout: self
-            clean: true
-            persistCredentials: true
-          - script: |
-              brew install terragrunt
-              brew install tflint
-              brew install checkov
-            displayName: Install dependencies
-          - template: steps/terraform_format.yml@templates
-          - template: steps/terragrunt_hclfmt.yml@templates
-          - template: steps/terraform_tflint.yml@templates
-            parameters:
-              moduleDirectories:
-                - $(Build.Repository.LocalPath)/app/modules
-                - $(Build.Repository.LocalPath)/app/stacks
-          - template: steps/run_checkov.yml@templates
-          - template: steps/terragrunt_validate.yml@templates
-            parameters:
-              serviceConnection: $(ADO_SERVICE_CONNECTION)
-              subscriptionId: $(SUBSCRIPTION_ID)
-              workingDirectory: $(Build.Repository.LocalPath)/app/stacks
-          - template: steps/git_tagging.yml@templates
-            parameters:
-              tagPrefix: infrastructure-environments
+extends:
+  template: stages/wrapper_ci.yml@templates
+  parameters:
+    azureLogin: true
+    azureServiceConnection: $(ADO_SERVICE_CONNECTION)
+    validateName: Validate Terraform
+    validationSteps:
+      - script: |
+          brew install terragrunt
+          brew install tflint
+          brew install checkov
+        displayName: Install dependencies
+      - template: steps/terraform_format.yml@templates
+      - template: steps/terragrunt_hclfmt.yml@templates
+      - template: steps/terraform_tflint.yml@templates
+        parameters:
+          moduleDirectories:
+            - $(Build.Repository.LocalPath)/app/modules
+            - $(Build.Repository.LocalPath)/app/stacks
+      - template: steps/run_checkov.yml@templates
+      - template: steps/terragrunt_validate_all.yml@templates
+        parameters:
+          subscriptionId: $(SUBSCRIPTION_ID)
+          workingDirectory: $(Build.Repository.LocalPath)/app/stacks

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -4,7 +4,6 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: feature/ci-stage-wrapper
 
 pool:
   vmImage: ubuntu-latest


### PR DESCRIPTION
- Use the wrapper_ci template instead of defining a load of steps ourselves