### PR TITLE
Separate private endpoint subnets per app stack

### DIFF
--- a/app/modules/node-app-service/README.md
+++ b/app/modules/node-app-service/README.md
@@ -40,8 +40,8 @@ No modules.
 | <a name="input_container_image_tag"></a> [container\_image\_tag](#input\_container\_image\_tag) | The specific tag of the image to be deployed to the app service | `string` | n/a | yes |
 | <a name="input_container_registry_id"></a> [container\_registry\_id](#input\_container\_registry\_id) | The id of the container registry that contains the image | `string` | n/a | yes |
 | <a name="input_container_registry_login_server"></a> [container\_registry\_login\_server](#input\_container\_registry\_login\_server) | The URL that can be used to log into the container registry | `string` | n/a | yes |
-| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
-| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
+| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | `null` | no |
+| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The name of the app service location | `string` | n/a | yes |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private dns zone, required if app\_type is 'backend' | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |

--- a/app/modules/node-app-service/README.md
+++ b/app/modules/node-app-service/README.md
@@ -40,12 +40,13 @@ No modules.
 | <a name="input_container_image_tag"></a> [container\_image\_tag](#input\_container\_image\_tag) | The specific tag of the image to be deployed to the app service | `string` | n/a | yes |
 | <a name="input_container_registry_id"></a> [container\_registry\_id](#input\_container\_registry\_id) | The id of the container registry that contains the image | `string` | n/a | yes |
 | <a name="input_container_registry_login_server"></a> [container\_registry\_login\_server](#input\_container\_registry\_login\_server) | The URL that can be used to log into the container registry | `string` | n/a | yes |
+| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
+| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The name of the app service location | `string` | n/a | yes |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private dns zone, required if app\_type is 'backend' | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix for resource naming | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | The name of the service the app belongs to | `string` | n/a | yes |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The id of the subnet the app service is deployed in | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags applied to the resource | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_private_endpoint" "private_endpoint" {
   name                = "pins-pe-${var.service_name}-${var.app_name}-${var.resource_suffix}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.subnet_id
+  subnet_id           = var.endpoint_subnet_id
 
   private_dns_zone_group {
     name                 = "privatednszonegroup"
@@ -78,5 +78,5 @@ resource "azurerm_app_service_virtual_network_swift_connection" "vnet_connection
   count = var.app_type == "frontend" ? 1 : 0
 
   app_service_id = azurerm_app_service.app_service.id
-  subnet_id      = var.subnet_id
+  subnet_id      = var.integration_subnet_id
 }

--- a/app/modules/node-app-service/variables.tf
+++ b/app/modules/node-app-service/variables.tf
@@ -55,6 +55,16 @@ variable "container_registry_login_server" {
   type        = string
 }
 
+variable "endpoint_subnet_id" {
+  description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
+  type        = string
+}
+
+variable "integration_subnet_id" {
+  description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
+  type        = string
+}
+
 variable "location" {
   description = "The name of the app service location"
   type        = string
@@ -78,11 +88,6 @@ variable "resource_suffix" {
 
 variable "service_name" {
   description = "The name of the service the app belongs to"
-  type        = string
-}
-
-variable "subnet_id" {
-  description = "The id of the subnet the app service is deployed in"
   type        = string
 }
 

--- a/app/modules/node-app-service/variables.tf
+++ b/app/modules/node-app-service/variables.tf
@@ -56,11 +56,13 @@ variable "container_registry_login_server" {
 }
 
 variable "endpoint_subnet_id" {
+  default     = null
   description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
   type        = string
 }
 
 variable "integration_subnet_id" {
+  default     = null
   description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   type        = string
 }

--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -43,10 +43,10 @@ No requirements.
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
-| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The subnet used for inbound traffic | `string` | n/a | yes |
+| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
-| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The subnet used for outbound traffic | `string` | n/a | yes |
+| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-south"` | no |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |

--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -41,9 +41,9 @@ No requirements.
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
-| <a name="input_common_network_name"></a> [common\_network\_name](#input\_common\_network\_name) | The common infrastructure network name | `string` | n/a | yes |
-| <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
+| <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |

--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -31,6 +31,7 @@ No requirements.
 |------|------|
 | [azurerm_cosmosdb_account.appeals_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 
 ## Inputs
@@ -40,10 +41,11 @@ No requirements.
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
+| <a name="input_common_network_name"></a> [common\_network\_name](#input\_common\_network\_name) | The common infrastructure network name | `string` | n/a | yes |
+| <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
-| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |

--- a/app/stacks/appeals-service/app-service.tf
+++ b/app/stacks/appeals-service/app-service.tf
@@ -14,7 +14,6 @@ module "lpa_questionnaire_frontend" {
   container_image_tag              = "latest"
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
@@ -71,7 +70,6 @@ module "appeal_service" {
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
   endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
-  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
@@ -140,7 +138,6 @@ module "appeal_reply_service" {
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
   endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
-  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
@@ -200,7 +197,6 @@ module "documents_service" {
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
   endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
-  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
@@ -244,7 +240,6 @@ module "pdf_service" {
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
   endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
-  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name

--- a/app/stacks/appeals-service/app-service.tf
+++ b/app/stacks/appeals-service/app-service.tf
@@ -14,7 +14,7 @@ module "lpa_questionnaire_frontend" {
   container_image_tag              = "latest"
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
@@ -70,7 +70,7 @@ module "appeal_service" {
   container_image_tag              = "latest"
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
@@ -139,7 +139,7 @@ module "appeal_reply_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
@@ -199,7 +199,7 @@ module "documents_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
@@ -243,7 +243,7 @@ module "pdf_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.appeals_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id

--- a/app/stacks/appeals-service/app-service.tf
+++ b/app/stacks/appeals-service/app-service.tf
@@ -14,11 +14,12 @@ module "lpa_questionnaire_frontend" {
   container_image_tag              = "latest"
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.integration_subnet_id
 
   app_settings = {
     ALLOW_APPEAL_REPLY_CREATE                = "true"
@@ -69,12 +70,13 @@ module "appeal_service" {
   container_image_tag              = "latest"
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.endpoint_subnet_id
 
   app_settings = {
     APP_APPEALS_BASE_URL                                                        = ""
@@ -137,12 +139,13 @@ module "appeal_reply_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.endpoint_subnet_id
 
   app_settings = {
     APPEALS_SERVICE_API_URL                                          = module.appeal_service.default_site_hostname
@@ -196,12 +199,13 @@ module "documents_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.endpoint_subnet_id
 
   app_settings = {
     BLOB_STORAGE_CONNECTION_STRING      = ""
@@ -239,12 +243,13 @@ module "pdf_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.appeals_service_stack.location
   private_dns_zone_id              = var.private_dns_zone_id
   resource_group_name              = azurerm_resource_group.appeals_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.endpoint_subnet_id
 
   app_settings = {
     DOCS_API_PATH                           = "/opt/app/api"

--- a/app/stacks/appeals-service/subnet.tf
+++ b/app/stacks/appeals-service/subnet.tf
@@ -1,0 +1,7 @@
+resource "azurerm_subnet" "appeals_service_ingress" {
+  name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
+  resource_group_name                            = var.common_resource_group_name
+  virtual_network_name                           = var.common_network_name
+  address_prefixes                               = ["10.0.2.0/24"]
+  enforce_private_link_endpoint_network_policies = true
+}

--- a/app/stacks/appeals-service/subnet.tf
+++ b/app/stacks/appeals-service/subnet.tf
@@ -1,7 +1,7 @@
 resource "azurerm_subnet" "appeals_service_ingress" {
   name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
-  resource_group_name                            = var.common_resource_group_name
-  virtual_network_name                           = var.common_network_name
+  resource_group_name                            = var.common_vnet_resource_group_name
+  virtual_network_name                           = var.common_vnet_name
   address_prefixes                               = ["10.0.2.0/24"]
   enforce_private_link_endpoint_network_policies = true
 }

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -11,8 +11,8 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    common_network_name              = "mock_network_name"
-    common_resource_group_name       = "mock_resource_group_name"
+    common_vnet_name                 = "mock_vnet_name"
+    common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
   }
@@ -22,8 +22,8 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  common_network_name              = dependency.common.outputs.common_network_name
-  common_resource_group_name       = dependency.common.outputs.common_resource_group_name
+  common_vnet_name                 = dependency.common.outputs.common_vnet_name
+  common_vnet_resource_group_name  = dependency.common.outputs.common_vnet_resource_group_name
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -21,7 +21,7 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  endpoint_subnet_id               = dependency.common.outputs.endpoint_subnet_id
+  endpoint_subnet_id               = dependency.common.outputs.endpoint_subnet_appeals_service_id
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -11,7 +11,8 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    endpoint_subnet_id               = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
+    common_network_name              = "mock_network_name"
+    common_resource_group_name       = "mock_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
   }

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -21,7 +21,8 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  endpoint_subnet_id               = dependency.common.outputs.endpoint_subnet_appeals_service_id
+  common_network_name              = dependency.common.outputs.common_network_name
+  common_resource_group_name       = dependency.common.outputs.common_resource_group_name
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -36,7 +36,7 @@ variable "environment" {
 }
 
 variable "endpoint_subnet_id" {
-  description = "The subnet used for inbound traffic"
+  description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
   type        = string
 }
 
@@ -47,7 +47,7 @@ variable "instance" {
 }
 
 variable "integration_subnet_id" {
-  description = "The subnet used for outbound traffic"
+  description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   type        = string
 }
 

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -15,6 +15,16 @@ variable "app_service_plan_id" {
   type        = string
 }
 
+variable "common_network_name" {
+  description = "The common infrastructure network name"
+  type        = string
+}
+
+variable "common_resource_group_name" {
+  description = "The common infrastructure resource group name"
+  type        = string
+}
+
 variable "common_tags" {
   description = "The common resource tags for the project"
   type        = map(string)
@@ -35,10 +45,10 @@ variable "environment" {
   type        = string
 }
 
-variable "endpoint_subnet_id" {
-  description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
-  type        = string
-}
+# variable "endpoint_subnet_id" {
+#   description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
+#   type        = string
+# }
 
 variable "instance" {
   description = "The environment instance for use if multiple environments are deployed to a subscription"

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -15,13 +15,13 @@ variable "app_service_plan_id" {
   type        = string
 }
 
-variable "common_network_name" {
-  description = "The common infrastructure network name"
+variable "common_vnet_name" {
+  description = "The common infrastructure virtual network name"
   type        = string
 }
 
-variable "common_resource_group_name" {
-  description = "The common infrastructure resource group name"
+variable "common_vnet_resource_group_name" {
+  description = "The common infrastructure virtual network resource group name"
   type        = string
 }
 

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -45,11 +45,6 @@ variable "environment" {
   type        = string
 }
 
-# variable "endpoint_subnet_id" {
-#   description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
-#   type        = string
-# }
-
 variable "instance" {
   description = "The environment instance for use if multiple environments are deployed to a subscription"
   type        = string

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -39,10 +39,10 @@ No requirements.
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
-| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The subnet used for inbound traffic | `string` | n/a | yes |
+| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
-| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The subnet used for outbound traffic | `string` | n/a | yes |
+| <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-south"` | no |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -37,9 +37,9 @@ No requirements.
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
-| <a name="input_common_network_name"></a> [common\_network\_name](#input\_common\_network\_name) | The common infrastructure network name | `string` | n/a | yes |
-| <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
+| <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -27,6 +27,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 
 ## Inputs
@@ -36,10 +37,11 @@ No requirements.
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
+| <a name="input_common_network_name"></a> [common\_network\_name](#input\_common\_network\_name) | The common infrastructure network name | `string` | n/a | yes |
+| <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
-| <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |

--- a/app/stacks/applications-service/app-service.tf
+++ b/app/stacks/applications-service/app-service.tf
@@ -10,11 +10,12 @@ module "national_infrastructure_frontend" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.applications_service_stack.location
   resource_group_name              = azurerm_resource_group.applications_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.integration_subnet_id
 
   app_settings = {
 
@@ -35,12 +36,13 @@ module "national_infrastructure_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
+  endpoint_subnet_id               = var.endpoint_subnet_id
+  integration_subnet_id            = var.integration_subnet_id
   private_dns_zone_id              = var.private_dns_zone_id
   location                         = azurerm_resource_group.applications_service_stack.location
   resource_group_name              = azurerm_resource_group.applications_service_stack.name
   resource_suffix                  = local.resource_suffix
   service_name                     = local.service_name
-  subnet_id                        = var.endpoint_subnet_id
 
   app_settings = {
 

--- a/app/stacks/applications-service/app-service.tf
+++ b/app/stacks/applications-service/app-service.tf
@@ -10,7 +10,6 @@ module "national_infrastructure_frontend" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = azurerm_subnet.applicatons_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.applications_service_stack.location
   resource_group_name              = azurerm_resource_group.applications_service_stack.name
@@ -37,7 +36,6 @@ module "national_infrastructure_service" {
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
   endpoint_subnet_id               = azurerm_subnet.applicatons_service_ingress.id
-  integration_subnet_id            = var.integration_subnet_id
   private_dns_zone_id              = var.private_dns_zone_id
   location                         = azurerm_resource_group.applications_service_stack.location
   resource_group_name              = azurerm_resource_group.applications_service_stack.name

--- a/app/stacks/applications-service/app-service.tf
+++ b/app/stacks/applications-service/app-service.tf
@@ -10,7 +10,7 @@ module "national_infrastructure_frontend" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.applicatons_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   location                         = azurerm_resource_group.applications_service_stack.location
   resource_group_name              = azurerm_resource_group.applications_service_stack.name
@@ -36,7 +36,7 @@ module "national_infrastructure_service" {
   container_image_tag              = ""
   container_registry_id            = data.azurerm_container_registry.acr.id
   container_registry_login_server  = data.azurerm_container_registry.acr.login_server
-  endpoint_subnet_id               = var.endpoint_subnet_id
+  endpoint_subnet_id               = azurerm_subnet.applicatons_service_ingress.id
   integration_subnet_id            = var.integration_subnet_id
   private_dns_zone_id              = var.private_dns_zone_id
   location                         = azurerm_resource_group.applications_service_stack.location

--- a/app/stacks/applications-service/subnet.tf
+++ b/app/stacks/applications-service/subnet.tf
@@ -1,0 +1,7 @@
+resource "azurerm_subnet" "applicatons_service_ingress" {
+  name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
+  resource_group_name                            = var.common_resource_group_name
+  virtual_network_name                           = var.common_network_name
+  address_prefixes                               = ["10.0.3.0/24"]
+  enforce_private_link_endpoint_network_policies = true
+}

--- a/app/stacks/applications-service/subnet.tf
+++ b/app/stacks/applications-service/subnet.tf
@@ -1,7 +1,7 @@
 resource "azurerm_subnet" "applicatons_service_ingress" {
   name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
-  resource_group_name                            = var.common_resource_group_name
-  virtual_network_name                           = var.common_network_name
+  resource_group_name                            = var.common_vnet_resource_group_name
+  virtual_network_name                           = var.common_vnet_name
   address_prefixes                               = ["10.0.3.0/24"]
   enforce_private_link_endpoint_network_policies = true
 }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -11,8 +11,8 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    common_network_name              = "mock_network_name"
-    common_resource_group_name       = "mock_resource_group_name"
+    common_vnet_name                 = "mock_vnet_name"
+    common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
   }
@@ -22,8 +22,8 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  common_network_name              = dependency.common.outputs.common_network_name
-  common_resource_group_name       = dependency.common.outputs.common_resource_group_name
+  common_vnet_name                 = dependency.common.outputs.common_vnet_name
+  common_vnet_resource_group_name  = dependency.common.outputs.common_vnet_resource_group_name
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -21,7 +21,7 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  endpoint_subnet_id               = dependency.common.outputs.endpoint_subnet_id
+  endpoint_subnet_id               = dependency.common.outputs.endpoint_subnet_applications_service_id
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -11,7 +11,8 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    endpoint_subnet_id               = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
+    common_network_name              = "mock_network_name"
+    common_resource_group_name       = "mock_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
   }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -21,7 +21,8 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  endpoint_subnet_id               = dependency.common.outputs.endpoint_subnet_applications_service_id
+  common_network_name              = dependency.common.outputs.common_network_name
+  common_resource_group_name       = dependency.common.outputs.common_resource_group_name
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -40,11 +40,6 @@ variable "container_registry_rg" {
   type        = string
 }
 
-# variable "endpoint_subnet_id" {
-#   description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
-#   type        = string
-# }
-
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
   type        = string

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -15,13 +15,13 @@ variable "app_service_plan_id" {
   type        = string
 }
 
-variable "common_network_name" {
-  description = "The common infrastructure network name"
+variable "common_vnet_name" {
+  description = "The common infrastructure virtual network name"
   type        = string
 }
 
-variable "common_resource_group_name" {
-  description = "The common infrastructure resource group name"
+variable "common_vnet_resource_group_name" {
+  description = "The common infrastructure virtual network resource group name"
   type        = string
 }
 

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -31,7 +31,7 @@ variable "container_registry_rg" {
 }
 
 variable "endpoint_subnet_id" {
-  description = "The subnet used for inbound traffic"
+  description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
   type        = string
 }
 
@@ -47,7 +47,7 @@ variable "instance" {
 }
 
 variable "integration_subnet_id" {
-  description = "The subnet used for outbound traffic"
+  description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   type        = string
 }
 

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -15,6 +15,16 @@ variable "app_service_plan_id" {
   type        = string
 }
 
+variable "common_network_name" {
+  description = "The common infrastructure network name"
+  type        = string
+}
+
+variable "common_resource_group_name" {
+  description = "The common infrastructure resource group name"
+  type        = string
+}
+
 variable "common_tags" {
   description = "The common resource tags for the project"
   type        = map(string)
@@ -30,10 +40,10 @@ variable "container_registry_rg" {
   type        = string
 }
 
-variable "endpoint_subnet_id" {
-  description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
-  type        = string
-}
+# variable "endpoint_subnet_id" {
+#   description = "The id of the private endpoint subnet the app service is linked to for ingress traffic"
+#   type        = string
+# }
 
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -28,10 +28,8 @@ No requirements.
 | [azurerm_private_dns_zone.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_resource_group.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-| [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.integration_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-| [azurerm_virtual_network.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 
 ## Inputs
 
@@ -49,8 +47,8 @@ No requirements.
 | <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
 | <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
-| <a name="output_endpoint_subnet_appeals_service_id"></a> [endpoint\_subnet\_appeals\_service\_id](#output\_endpoint\_subnet\_appeals\_service\_id) | The id of the private endpoint subnet the appeals service apps are linked to for ingress traffic |
-| <a name="output_endpoint_subnet_applications_service_id"></a> [endpoint\_subnet\_applications\_service\_id](#output\_endpoint\_subnet\_applications\_service\_id) | The id of the private endpoint subnet the applications service apps are linked to for ingress traffic |
+| <a name="output_common_network_name"></a> [common\_network\_name](#output\_common\_network\_name) | The name of the common infrastructure virtual network |
+| <a name="output_common_resource_group_name"></a> [common\_resource\_group\_name](#output\_common\_resource\_group\_name) | The name of the common infrastructure resource group |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -28,7 +28,8 @@ No requirements.
 | [azurerm_private_dns_zone.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_resource_group.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_subnet.endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.integration_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 
@@ -48,7 +49,8 @@ No requirements.
 | <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
 | <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
-| <a name="output_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#output\_endpoint\_subnet\_id) | The subnet used for inbound traffic |
-| <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The subnet used for outbound traffic |
+| <a name="output_endpoint_subnet_appeals_service_id"></a> [endpoint\_subnet\_appeals\_service\_id](#output\_endpoint\_subnet\_appeals\_service\_id) | The id of the private endpoint subnet the appeals service apps are linked to for ingress traffic |
+| <a name="output_endpoint_subnet_applications_service_id"></a> [endpoint\_subnet\_applications\_service\_id](#output\_endpoint\_subnet\_applications\_service\_id) | The id of the private endpoint subnet the applications service apps are linked to for ingress traffic |
+| <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -47,8 +47,8 @@ No requirements.
 | <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
 | <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
-| <a name="output_common_network_name"></a> [common\_network\_name](#output\_common\_network\_name) | The name of the common infrastructure virtual network |
-| <a name="output_common_resource_group_name"></a> [common\_resource\_group\_name](#output\_common\_resource\_group\_name) | The name of the common infrastructure resource group |
+| <a name="output_common_vnet_name"></a> [common\_vnet\_name](#output\_common\_vnet\_name) | The name of the common infrastructure virtual network |
+| <a name="output_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#output\_common\_vnet\_resource\_group\_name) | The name of the common infrastructure virtual network resource group |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -23,22 +23,6 @@ resource "azurerm_subnet" "integration_subnet" {
   }
 }
 
-# resource "azurerm_subnet" "common_infrastructure_ingress" {
-#   name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
-#   resource_group_name                            = azurerm_resource_group.common_infrastructure.name
-#   virtual_network_name                           = azurerm_virtual_network.common_infrastructure.name
-#   address_prefixes                               = ["10.0.2.0/24"]
-#   enforce_private_link_endpoint_network_policies = true
-# }
-
-# resource "azurerm_subnet" "applicatons_service_ingress" {
-#   name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
-#   resource_group_name                            = azurerm_resource_group.common_infrastructure.name
-#   virtual_network_name                           = azurerm_virtual_network.common_infrastructure.name
-#   address_prefixes                               = ["10.0.3.0/24"]
-#   enforce_private_link_endpoint_network_policies = true
-# }
-
 resource "azurerm_private_dns_zone" "private_link" {
   name                = "privatelink.azurewebsites.net"
   resource_group_name = azurerm_resource_group.common_infrastructure.name

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -23,11 +23,19 @@ resource "azurerm_subnet" "integration_subnet" {
   }
 }
 
-resource "azurerm_subnet" "endpoint_subnet" {
-  name                                           = "pins-snet-${local.service_name}-endpoint-${local.resource_suffix}"
+resource "azurerm_subnet" "appeals_service_ingress" {
+  name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
   resource_group_name                            = azurerm_resource_group.common_infrastructure.name
   virtual_network_name                           = azurerm_virtual_network.appeals_service.name
   address_prefixes                               = ["10.0.2.0/24"]
+  enforce_private_link_endpoint_network_policies = true
+}
+
+resource "azurerm_subnet" "applicatons_service_ingress" {
+  name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
+  resource_group_name                            = azurerm_resource_group.common_infrastructure.name
+  virtual_network_name                           = azurerm_virtual_network.appeals_service.name
+  address_prefixes                               = ["10.0.3.0/24"]
   enforce_private_link_endpoint_network_policies = true
 }
 

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -1,4 +1,4 @@
-resource "azurerm_virtual_network" "appeals_service" {
+resource "azurerm_virtual_network" "common_infrastructure" {
   name                = "pins-vnet-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.common_infrastructure.location
   resource_group_name = azurerm_resource_group.common_infrastructure.name
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network" "appeals_service" {
 resource "azurerm_subnet" "integration_subnet" {
   name                 = "pins-snet-${local.service_name}-integration-${local.resource_suffix}"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
-  virtual_network_name = azurerm_virtual_network.appeals_service.name
+  virtual_network_name = azurerm_virtual_network.common_infrastructure.name
   address_prefixes     = ["10.0.1.0/24"]
 
   delegation {
@@ -23,21 +23,21 @@ resource "azurerm_subnet" "integration_subnet" {
   }
 }
 
-resource "azurerm_subnet" "appeals_service_ingress" {
-  name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
-  resource_group_name                            = azurerm_resource_group.common_infrastructure.name
-  virtual_network_name                           = azurerm_virtual_network.appeals_service.name
-  address_prefixes                               = ["10.0.2.0/24"]
-  enforce_private_link_endpoint_network_policies = true
-}
+# resource "azurerm_subnet" "common_infrastructure_ingress" {
+#   name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
+#   resource_group_name                            = azurerm_resource_group.common_infrastructure.name
+#   virtual_network_name                           = azurerm_virtual_network.common_infrastructure.name
+#   address_prefixes                               = ["10.0.2.0/24"]
+#   enforce_private_link_endpoint_network_policies = true
+# }
 
-resource "azurerm_subnet" "applicatons_service_ingress" {
-  name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
-  resource_group_name                            = azurerm_resource_group.common_infrastructure.name
-  virtual_network_name                           = azurerm_virtual_network.appeals_service.name
-  address_prefixes                               = ["10.0.3.0/24"]
-  enforce_private_link_endpoint_network_policies = true
-}
+# resource "azurerm_subnet" "applicatons_service_ingress" {
+#   name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
+#   resource_group_name                            = azurerm_resource_group.common_infrastructure.name
+#   virtual_network_name                           = azurerm_virtual_network.common_infrastructure.name
+#   address_prefixes                               = ["10.0.3.0/24"]
+#   enforce_private_link_endpoint_network_policies = true
+# }
 
 resource "azurerm_private_dns_zone" "private_link" {
   name                = "privatelink.azurewebsites.net"
@@ -48,5 +48,5 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private_link" {
   name                  = "pins-vnetlink-${local.service_name}-${local.resource_suffix}"
   resource_group_name   = azurerm_resource_group.common_infrastructure.name
   private_dns_zone_name = azurerm_private_dns_zone.private_link.name
-  virtual_network_id    = azurerm_virtual_network.appeals_service.id
+  virtual_network_id    = azurerm_virtual_network.common_infrastructure.id
 }

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -15,13 +15,13 @@ output "app_service_plan_id" {
   value       = azurerm_app_service_plan.common_service_plan.id
 }
 
-output "common_network_name" {
+output "common_vnet_name" {
   description = "The name of the common infrastructure virtual network"
   value       = azurerm_virtual_network.common_infrastructure.name
 }
 
-output "common_resource_group_name" {
-  description = "The name of the common infrastructure resource group"
+output "common_vnet_resource_group_name" {
+  description = "The name of the common infrastructure virtual network resource group"
   value       = azurerm_resource_group.common_infrastructure.name
 }
 

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -15,14 +15,14 @@ output "app_service_plan_id" {
   value       = azurerm_app_service_plan.common_service_plan.id
 }
 
-output "common_resource_group_name" {
-  description = "The name of the common infrastructure resource group"
-  value       = azurerm_resource_group.common_infrastructure.name
-}
-
 output "common_network_name" {
   description = "The name of the common infrastructure virtual network"
   value       = azurerm_virtual_network.common_infrastructure.name
+}
+
+output "common_resource_group_name" {
+  description = "The name of the common infrastructure resource group"
+  value       = azurerm_resource_group.common_infrastructure.name
 }
 
 output "integration_subnet_id" {

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -15,15 +15,25 @@ output "app_service_plan_id" {
   value       = azurerm_app_service_plan.common_service_plan.id
 }
 
-output "endpoint_subnet_appeals_service_id" {
-  description = "The id of the private endpoint subnet the appeals service apps are linked to for ingress traffic"
-  value       = azurerm_subnet.appeals_service_ingress.id
+output "common_resource_group_name" {
+  description = "The name of the common infrastructure resource group"
+  value       = azurerm_resource_group.common_infrastructure.name
 }
 
-output "endpoint_subnet_applications_service_id" {
-  description = "The id of the private endpoint subnet the applications service apps are linked to for ingress traffic"
-  value       = azurerm_subnet.applicatons_service_ingress.id
+output "common_network_name" {
+  description = "The name of the common infrastructure virtual network"
+  value       = azurerm_virtual_network.common_infrastructure.name
 }
+
+# output "endpoint_subnet_appeals_service_id" {
+#   description = "The id of the private endpoint subnet the appeals service apps are linked to for ingress traffic"
+#   value       = azurerm_subnet.appeals_service_ingress.id
+# }
+
+# output "endpoint_subnet_applications_service_id" {
+#   description = "The id of the private endpoint subnet the applications service apps are linked to for ingress traffic"
+#   value       = azurerm_subnet.applicatons_service_ingress.id
+# }
 
 output "integration_subnet_id" {
   description = "The id of the vnet integration subnet the app service is linked to for egress traffic"

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -15,13 +15,18 @@ output "app_service_plan_id" {
   value       = azurerm_app_service_plan.common_service_plan.id
 }
 
-output "endpoint_subnet_id" {
-  description = "The subnet used for inbound traffic"
-  value       = azurerm_subnet.endpoint_subnet.id
+output "endpoint_subnet_appeals_service_id" {
+  description = "The id of the private endpoint subnet the appeals service apps are linked to for ingress traffic"
+  value       = azurerm_subnet.appeals_service_ingress.id
+}
+
+output "endpoint_subnet_applications_service_id" {
+  description = "The id of the private endpoint subnet the applications service apps are linked to for ingress traffic"
+  value       = azurerm_subnet.applicatons_service_ingress.id
 }
 
 output "integration_subnet_id" {
-  description = "The subnet used for outbound traffic"
+  description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   value       = azurerm_subnet.integration_subnet.id
 }
 

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -25,16 +25,6 @@ output "common_network_name" {
   value       = azurerm_virtual_network.common_infrastructure.name
 }
 
-# output "endpoint_subnet_appeals_service_id" {
-#   description = "The id of the private endpoint subnet the appeals service apps are linked to for ingress traffic"
-#   value       = azurerm_subnet.appeals_service_ingress.id
-# }
-
-# output "endpoint_subnet_applications_service_id" {
-#   description = "The id of the private endpoint subnet the applications service apps are linked to for ingress traffic"
-#   value       = azurerm_subnet.applicatons_service_ingress.id
-# }
-
 output "integration_subnet_id" {
   description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   value       = azurerm_subnet.integration_subnet.id


### PR DESCRIPTION
This PR separates out the private endpoint subnets for each app stack so that security filtering or routing may be applied more easily if desired later.

- Remove subnet definitions from the common VNET file.
- Add outputs for VNET name and resource group name to the common stack.
- Add individual subnet files to each app stack.
- Update the the app service module has correct inputs for the ingress and egress subnets.
- Update inputs and mock values for Terragrunt.

At the time of writing there is throttling in effect for Cosmos DB which will affect deployment to the Dev environment. This branch has already been successfully deployed (manually) to the Test and Production environments.