### PR TITLE
Assign VNET address space per environment and dynamically create subnet prefixes

### DIFF
--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -42,7 +42,7 @@ No requirements.
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
-| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(any)` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |

--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -42,7 +42,7 @@ No requirements.
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
-| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(any)` | n/a | yes |
+| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |

--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -42,6 +42,7 @@ No requirements.
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |

--- a/app/stacks/appeals-service/subnet.tf
+++ b/app/stacks/appeals-service/subnet.tf
@@ -2,6 +2,6 @@ resource "azurerm_subnet" "appeals_service_ingress" {
   name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
   resource_group_name                            = var.common_vnet_resource_group_name
   virtual_network_name                           = var.common_vnet_name
-  address_prefixes                               = [var.common_vnet_cidr_blocks.appeals_service_endpoints]
+  address_prefixes                               = [var.common_vnet_cidr_blocks["appeals_service_endpoints"]]
   enforce_private_link_endpoint_network_policies = true
 }

--- a/app/stacks/appeals-service/subnet.tf
+++ b/app/stacks/appeals-service/subnet.tf
@@ -2,6 +2,6 @@ resource "azurerm_subnet" "appeals_service_ingress" {
   name                                           = "pins-snet-appeals-service-ingress-${local.resource_suffix}"
   resource_group_name                            = var.common_vnet_resource_group_name
   virtual_network_name                           = var.common_vnet_name
-  address_prefixes                               = ["10.0.2.0/24"]
+  address_prefixes                               = [var.common_vnet_cidr_blocks.appeals_service_endpoints]
   enforce_private_link_endpoint_network_policies = true
 }

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -11,6 +11,7 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
+    common_vnet_cidr_blocks          = tomap({ mock_key = "mock_value" })
     common_vnet_name                 = "mock_vnet_name"
     common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
@@ -22,6 +23,7 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
+  common_vnet_cidr_blocks          = dependency.common.outputs.common_vnet_cidr_blocks
   common_vnet_name                 = dependency.common.outputs.common_vnet_name
   common_vnet_resource_group_name  = dependency.common.outputs.common_vnet_resource_group_name
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -11,11 +11,17 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    common_vnet_cidr_blocks          = { mock_key = "mock_value" }
-    common_vnet_name                 = "mock_vnet_name"
-    common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
-    integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
-    private_dns_zone_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
+    common_vnet_cidr_blocks = {
+      app_gateway                    = "10.1.0.0/25"
+      app_service_integration        = "10.1.1.0/24"
+      appeals_service_endpoints      = "10.1.2.0/24"
+      applications_service_endpoints = "10.1.3.0/24"
+      vpn_gateway                    = "10.1.0.128/25"
+    }
+    common_vnet_name                = "mock_vnet_name"
+    common_vnet_resource_group_name = "mock_vnet_resource_group_name"
+    integration_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
+    private_dns_zone_id             = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
   }
 }
 

--- a/app/stacks/appeals-service/terragrunt.hcl
+++ b/app/stacks/appeals-service/terragrunt.hcl
@@ -11,7 +11,7 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    common_vnet_cidr_blocks          = tomap({ mock_key = "mock_value" })
+    common_vnet_cidr_blocks          = { mock_key = "mock_value" }
     common_vnet_name                 = "mock_vnet_name"
     common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -17,7 +17,7 @@ variable "app_service_plan_id" {
 
 variable "common_vnet_cidr_blocks" {
   description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
-  type        = map(string)
+  type        = map(any)
 }
 
 variable "common_vnet_name" {

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -17,7 +17,7 @@ variable "app_service_plan_id" {
 
 variable "common_vnet_cidr_blocks" {
   description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
-  type        = map(any)
+  type        = map(string)
 }
 
 variable "common_vnet_name" {

--- a/app/stacks/appeals-service/variables.tf
+++ b/app/stacks/appeals-service/variables.tf
@@ -15,6 +15,11 @@ variable "app_service_plan_id" {
   type        = string
 }
 
+variable "common_vnet_cidr_blocks" {
+  description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
+  type        = map(string)
+}
+
 variable "common_vnet_name" {
   description = "The common infrastructure virtual network name"
   type        = string

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -38,7 +38,7 @@ No requirements.
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
-| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(any)` | n/a | yes |
+| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -38,7 +38,7 @@ No requirements.
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
-| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(any)` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -38,6 +38,7 @@ No requirements.
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#input\_common\_vnet\_resource\_group\_name) | The common infrastructure virtual network resource group name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |

--- a/app/stacks/applications-service/subnet.tf
+++ b/app/stacks/applications-service/subnet.tf
@@ -2,6 +2,6 @@ resource "azurerm_subnet" "applicatons_service_ingress" {
   name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
   resource_group_name                            = var.common_vnet_resource_group_name
   virtual_network_name                           = var.common_vnet_name
-  address_prefixes                               = [var.common_vnet_cidr_blocks.applications_service_endpoints]
+  address_prefixes                               = [var.common_vnet_cidr_blocks["applications_service_endpoints"]]
   enforce_private_link_endpoint_network_policies = true
 }

--- a/app/stacks/applications-service/subnet.tf
+++ b/app/stacks/applications-service/subnet.tf
@@ -2,6 +2,6 @@ resource "azurerm_subnet" "applicatons_service_ingress" {
   name                                           = "pins-snet-applications-service-ingress-${local.resource_suffix}"
   resource_group_name                            = var.common_vnet_resource_group_name
   virtual_network_name                           = var.common_vnet_name
-  address_prefixes                               = ["10.0.3.0/24"]
+  address_prefixes                               = [var.common_vnet_cidr_blocks.applications_service_endpoints]
   enforce_private_link_endpoint_network_policies = true
 }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -11,6 +11,7 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
+    common_vnet_cidr_blocks          = tomap({ mock_key = "mock_value" })
     common_vnet_name                 = "mock_vnet_name"
     common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
@@ -22,6 +23,7 @@ inputs = {
   app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
   app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
+  common_vnet_cidr_blocks          = dependency.common.outputs.common_vnet_cidr_blocks
   common_vnet_name                 = dependency.common.outputs.common_vnet_name
   common_vnet_resource_group_name  = dependency.common.outputs.common_vnet_resource_group_name
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -11,11 +11,17 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    common_vnet_cidr_blocks          = { mock_key = "mock_value" }
-    common_vnet_name                 = "mock_vnet_name"
-    common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
-    integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
-    private_dns_zone_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
+    common_vnet_cidr_blocks = {
+      app_gateway                    = "10.1.0.0/25"
+      app_service_integration        = "10.1.1.0/24"
+      appeals_service_endpoints      = "10.1.2.0/24"
+      applications_service_endpoints = "10.1.3.0/24"
+      vpn_gateway                    = "10.1.0.128/25"
+    }
+    common_vnet_name                = "mock_vnet_name"
+    common_vnet_resource_group_name = "mock_vnet_resource_group_name"
+    integration_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
+    private_dns_zone_id             = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
   }
 }
 

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -11,7 +11,7 @@ dependency "common" {
     app_insights_connection_string   = "mock_connection_string"
     app_insights_instrumentation_key = "mock_instrumentation_key"
     app_service_plan_id              = "mock_id"
-    common_vnet_cidr_blocks          = tomap({ mock_key = "mock_value" })
+    common_vnet_cidr_blocks          = { mock_key = "mock_value" }
     common_vnet_name                 = "mock_vnet_name"
     common_vnet_resource_group_name  = "mock_vnet_resource_group_name"
     integration_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -17,7 +17,7 @@ variable "app_service_plan_id" {
 
 variable "common_vnet_cidr_blocks" {
   description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
-  type        = map(string)
+  type        = map(any)
 }
 
 variable "common_vnet_name" {

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -17,7 +17,7 @@ variable "app_service_plan_id" {
 
 variable "common_vnet_cidr_blocks" {
   description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
-  type        = map(any)
+  type        = map(string)
 }
 
 variable "common_vnet_name" {

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -15,6 +15,11 @@ variable "app_service_plan_id" {
   type        = string
 }
 
+variable "common_vnet_cidr_blocks" {
+  description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
+  type        = map(string)
+}
+
 variable "common_vnet_name" {
   description = "The common infrastructure virtual network name"
   type        = string

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -18,6 +18,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_region_uks"></a> [azure\_region\_uks](#module\_azure\_region\_uks) | claranet/regions/azurerm | 4.2.1 |
+| <a name="module_common_vnet_address_space"></a> [common\_vnet\_address\_space](#module\_common\_vnet\_address\_space) | hashicorp/subnets/cidr | 1.0.0 |
 
 ## Resources
 
@@ -28,7 +29,9 @@ No requirements.
 | [azurerm_private_dns_zone.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_resource_group.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.app_gateway_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.integration_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.vpn_gateway_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 
 ## Inputs
@@ -36,6 +39,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_address_space"></a> [common\_vnet\_address\_space](#input\_common\_vnet\_address\_space) | The CIDR address space for the common virtual network | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-south"` | no |
@@ -47,6 +51,7 @@ No requirements.
 | <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
 | <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
+| <a name="output_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#output\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix |
 | <a name="output_common_vnet_name"></a> [common\_vnet\_name](#output\_common\_vnet\_name) | The name of the common infrastructure virtual network |
 | <a name="output_common_vnet_resource_group_name"></a> [common\_vnet\_resource\_group\_name](#output\_common\_vnet\_resource\_group\_name) | The name of the common infrastructure virtual network resource group |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |

--- a/app/stacks/common/address-space.tf
+++ b/app/stacks/common/address-space.tf
@@ -1,0 +1,27 @@
+module "common_vnet_address_space" {
+  source          = "hashicorp/subnets/cidr"
+  version         = "1.0.0"
+  base_cidr_block = var.common_vnet_address_space
+  networks = [
+    {
+      name     = "app_gateway"
+      new_bits = 9 # /25 (123 usable) [0 - 127]
+    },
+    {
+      name     = "vpn_gateway"
+      new_bits = 9 # /25 (123 usable) [128 - 255]
+    },
+    {
+      name     = "app_service_integration"
+      new_bits = 8 # /24 (251 usable) [0 - 255]
+    },
+    {
+      name     = "appeals_service_endpoints"
+      new_bits = 8 # /24 (251 usable) [0 - 255]
+    },
+    {
+      name     = "applications_service_endpoints"
+      new_bits = 8 # /24 (251 usable) [0 - 255]
+    },
+  ]
+}

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -9,21 +9,21 @@ resource "azurerm_subnet" "app_gateway_subnet" {
   name                 = "pins-snet-${local.service_name}-agw-${local.resource_suffix}"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
   virtual_network_name = azurerm_virtual_network.common_infrastructure.name
-  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks.app_gateway]
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["app_gateway"]]
 }
 
 resource "azurerm_subnet" "vpn_gateway_subnet" {
   name                 = "pins-snet-${local.service_name}-vpn-${local.resource_suffix}"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
   virtual_network_name = azurerm_virtual_network.common_infrastructure.name
-  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks.vpn_gateway]
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["vpn_gateway"]]
 }
 
 resource "azurerm_subnet" "integration_subnet" {
   name                 = "pins-snet-${local.service_name}-integration-${local.resource_suffix}"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
   virtual_network_name = azurerm_virtual_network.common_infrastructure.name
-  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks.app_service_integration]
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["app_service_integration"]]
 
   delegation {
     name = "delegation"

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -2,14 +2,28 @@ resource "azurerm_virtual_network" "common_infrastructure" {
   name                = "pins-vnet-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.common_infrastructure.location
   resource_group_name = azurerm_resource_group.common_infrastructure.name
-  address_space       = ["10.0.0.0/16"]
+  address_space       = [module.common_vnet_address_space.base_cidr_block]
+}
+
+resource "azurerm_subnet" "app_gateway_subnet" {
+  name                 = "pins-snet-${local.service_name}-agw-${local.resource_suffix}"
+  resource_group_name  = azurerm_resource_group.common_infrastructure.name
+  virtual_network_name = azurerm_virtual_network.common_infrastructure.name
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks.app_gateway]
+}
+
+resource "azurerm_subnet" "vpn_gateway_subnet" {
+  name                 = "pins-snet-${local.service_name}-vpn-${local.resource_suffix}"
+  resource_group_name  = azurerm_resource_group.common_infrastructure.name
+  virtual_network_name = azurerm_virtual_network.common_infrastructure.name
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks.vpn_gateway]
 }
 
 resource "azurerm_subnet" "integration_subnet" {
   name                 = "pins-snet-${local.service_name}-integration-${local.resource_suffix}"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
   virtual_network_name = azurerm_virtual_network.common_infrastructure.name
-  address_prefixes     = ["10.0.1.0/24"]
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks.app_service_integration]
 
   delegation {
     name = "delegation"

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -15,6 +15,11 @@ output "app_service_plan_id" {
   value       = azurerm_app_service_plan.common_service_plan.id
 }
 
+output "common_vnet_cidr_blocks" {
+  description = "A map of IP address blocks from the subnet name to the allocated CIDR prefix"
+  value       = module.common_vnet_address_space.network_cidr_blocks
+}
+
 output "common_vnet_name" {
   description = "The name of the common infrastructure virtual network"
   value       = azurerm_virtual_network.common_infrastructure.name

--- a/app/stacks/common/variables.tf
+++ b/app/stacks/common/variables.tf
@@ -3,6 +3,12 @@ variable "common_tags" {
   type        = map(string)
 }
 
+variable "common_vnet_address_space" {
+  description = "The CIDR address space for the common virtual network"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
   type        = string

--- a/config/variables/dev.hcl
+++ b/config/variables/dev.hcl
@@ -1,3 +1,4 @@
 locals {
-  environment = "dev"
+  environment               = "dev"
+  common_vnet_address_space = "10.1.0.0/16"
 }

--- a/config/variables/prod.hcl
+++ b/config/variables/prod.hcl
@@ -1,3 +1,4 @@
 locals {
-  environment = "prod"
+  environment               = "prod"
+  common_vnet_address_space = "10.3.0.0/16"
 }

--- a/config/variables/test.hcl
+++ b/config/variables/test.hcl
@@ -1,3 +1,4 @@
 locals {
-  environment = "test"
+  environment               = "test"
+  common_vnet_address_space = "10.2.0.0/16"
 }

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -15,7 +15,9 @@ pool:
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
+    authType: terraform
     container: terraform-tools
+    projectName: infrastructure
     validateName: Validate Terraform
     validationSteps:
       - template: steps/terraform_format.yml@templates
@@ -26,9 +28,6 @@ extends:
             - $(Build.Repository.LocalPath)/app/modules
             - $(Build.Repository.LocalPath)/app/stacks
       - template: steps/run_checkov.yml@templates
-      - template: steps/terraform_azure_cli_auth.yml@templates
-        parameters:
-          azureServiceConnection: infrastructure-dev
       - template: steps/terragrunt_validate_all.yml@templates
         parameters:
           subscriptionId: $(SUBSCRIPTION_ID)


### PR DESCRIPTION
- Allows the common VNET address space to be specified individually for each environment.
- Dynamically creates subnet prefixes for each subnet based on the given VNET address space.
- Fix CI pipeline to work with common pipeline template updates.