### PR TITLE
Add virtual network gateway resources with key vault integration for shared key

### DIFF
--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -31,6 +31,8 @@ No requirements.
 | [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network_gateway_connection.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway_connection) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
+| [azurerm_key_vault.environment_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_secret.vnet_gateway_shared_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 
 ## Inputs
 
@@ -51,6 +53,7 @@ No requirements.
 | <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
+| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | The name of the common infrastructure key vault | `string` | n/a | yes |
 | <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_mysql_database"></a> [mysql\_database](#input\_mysql\_database) | The name of the database for the Applications Service | `string` | n/a | yes |

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -26,8 +26,12 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
+| [azurerm_public_ip.vpn_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network_gateway.applications_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway) | resource |
+| [azurerm_virtual_network_gateway_connection.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway_connection) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 
 ## Inputs
@@ -55,6 +59,7 @@ No requirements.
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-south"` | no |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |
+| <a name="input_vpn_gateway_subnet_id"></a> [vpn\_gateway\_subnet\_id](#input\_vpn\_gateway\_subnet\_id) | The id of the VPN gateway subnet | `string` | n/a | yes |
 
 ## Outputs
 

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -27,10 +27,8 @@ No requirements.
 | Name | Type |
 |------|------|
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
-| [azurerm_public_ip.vpn_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-| [azurerm_virtual_network_gateway.applications_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway) | resource |
 | [azurerm_virtual_network_gateway_connection.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway_connection) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 
@@ -45,6 +43,7 @@ No requirements.
 | <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
 | <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
+| <a name="input_common_vnet_gateway_id"></a> [common\_vnet\_gateway\_id](#input\_common\_vnet\_gateway\_id) | The id of the common infrastructure virtual network gateway | `string` | n/a | yes |
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
@@ -59,7 +58,6 @@ No requirements.
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-south"` | no |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |
-| <a name="input_vpn_gateway_subnet_id"></a> [vpn\_gateway\_subnet\_id](#input\_vpn\_gateway\_subnet\_id) | The id of the VPN gateway subnet | `string` | n/a | yes |
 
 ## Outputs
 

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -55,6 +55,8 @@ No requirements.
 | <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_mysql_database"></a> [mysql\_database](#input\_mysql\_database) | The name of the database for the Applications Service | `string` | n/a | yes |
+| <a name="input_national_infrastructure_gateway_ip"></a> [national\_infrastructure\_gateway\_ip](#input\_national\_infrastructure\_gateway\_ip) | The public IP address of the National Infrastructure gateway endpoint | `string` | n/a | yes |
+| <a name="input_national_infrastructure_vnet_address_space"></a> [national\_infrastructure\_vnet\_address\_space](#input\_national\_infrastructure\_vnet\_address\_space) | The address space advertised by the National Infrastructure gateway endpoint | `list(string)` | n/a | yes |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-south"` | no |

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -31,8 +31,6 @@ No requirements.
 | [azurerm_subnet.applicatons_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network_gateway_connection.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway_connection) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
-| [azurerm_key_vault.environment_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.vnet_gateway_shared_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 
 ## Inputs
 
@@ -42,6 +40,7 @@ No requirements.
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
+| <a name="input_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#input\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key | `string` | n/a | yes |
 | <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
 | <a name="input_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#input\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix | `map(string)` | n/a | yes |
@@ -53,7 +52,6 @@ No requirements.
 | <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
-| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | The name of the common infrastructure key vault | `string` | n/a | yes |
 | <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_mysql_database"></a> [mysql\_database](#input\_mysql\_database) | The name of the database for the Applications Service | `string` | n/a | yes |

--- a/app/stacks/applications-service/data.tf
+++ b/app/stacks/applications-service/data.tf
@@ -4,3 +4,13 @@ data "azurerm_container_registry" "acr" {
 
   provider = azurerm.tooling
 }
+
+data "azurerm_key_vault" "environment_key_vault" {
+  name                = var.key_vault_name
+  resource_group_name = var.common_resource_group_name
+}
+
+data "azurerm_key_vault_secret" "vnet_gateway_shared_key" {
+  name         = "applications-service-vpn-gateway-shared-key"
+  key_vault_id = data.azurerm_key_vault.environment_key_vault.id
+}

--- a/app/stacks/applications-service/data.tf
+++ b/app/stacks/applications-service/data.tf
@@ -4,13 +4,3 @@ data "azurerm_container_registry" "acr" {
 
   provider = azurerm.tooling
 }
-
-data "azurerm_key_vault" "environment_key_vault" {
-  name                = var.key_vault_name
-  resource_group_name = var.common_resource_group_name
-}
-
-data "azurerm_key_vault_secret" "vnet_gateway_shared_key" {
-  name         = "applications-service-vpn-gateway-shared-key"
-  key_vault_id = data.azurerm_key_vault.environment_key_vault.id
-}

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -29,7 +29,7 @@ dependency "common" {
     }
     integration_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
-    vpn_gateway_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
+    vpn_gateway_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworks/mock_vnet/subnets/GatewaySubnet"
   }
 }
 

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -21,6 +21,7 @@ dependency "common" {
     }
     common_vnet_gateway_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworkGateways/mock_id"
     common_vnet_name       = "mock_vnet_name"
+    key_vault_name         = "mock_key_vault_name"
     key_vault_secret_refs = {
       applications-service-encryption-secret-key = "mock_secret"
       applications-service-mysql-host            = "mock_secret"
@@ -41,6 +42,7 @@ inputs = {
   common_vnet_cidr_blocks          = dependency.common.outputs.common_vnet_cidr_blocks
   common_vnet_gateway_id           = dependency.common.outputs.common_vnet_gateway_id
   common_vnet_name                 = dependency.common.outputs.common_vnet_name
+  key_vault_name                   = dependency.common.outputs.key_vault_name
   key_vault_secret_refs            = dependency.common.outputs.key_vault_secret_refs
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -29,7 +29,7 @@ dependency "common" {
     }
     integration_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
-    vpn_gateway_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
+    vpn_gateway_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
   }
 }
 

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -19,7 +19,8 @@ dependency "common" {
       applications_service_endpoints = "10.1.3.0/24"
       vpn_gateway                    = "10.1.0.128/25"
     }
-    common_vnet_name = "mock_vnet_name"
+    common_vnet_gateway_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworkGateways/mock_id"
+    common_vnet_name       = "mock_vnet_name"
     key_vault_secret_refs = {
       applications-service-encryption-secret-key = "mock_secret"
       applications-service-mysql-host            = "mock_secret"
@@ -29,7 +30,6 @@ dependency "common" {
     }
     integration_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
-    vpn_gateway_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworks/mock_vnet/subnets/GatewaySubnet"
   }
 }
 
@@ -39,9 +39,9 @@ inputs = {
   app_service_plan_id              = dependency.common.outputs.app_service_plan_id
   common_resource_group_name       = dependency.common.outputs.common_resource_group_name
   common_vnet_cidr_blocks          = dependency.common.outputs.common_vnet_cidr_blocks
+  common_vnet_gateway_id           = dependency.common.outputs.common_vnet_gateway_id
   common_vnet_name                 = dependency.common.outputs.common_vnet_name
   key_vault_secret_refs            = dependency.common.outputs.key_vault_secret_refs
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
-  vpn_gateway_subnet_id            = dependency.common.outputs.vpn_gateway_subnet_id
 }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -21,7 +21,7 @@ dependency "common" {
     }
     common_vnet_gateway_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworkGateways/mock_id"
     common_vnet_name       = "mock_vnet_name"
-    key_vault_name         = "mock_key_vault_name"
+    key_vault_name         = "mockkeyvaultname"
     key_vault_secret_refs = {
       applications-service-encryption-secret-key = "mock_secret"
       applications-service-mysql-host            = "mock_secret"

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -29,6 +29,7 @@ dependency "common" {
     }
     integration_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     private_dns_zone_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/privateDnsZones/mock_id"
+    vpn_gateway_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
   }
 }
 
@@ -42,4 +43,5 @@ inputs = {
   key_vault_secret_refs            = dependency.common.outputs.key_vault_secret_refs
   integration_subnet_id            = dependency.common.outputs.integration_subnet_id
   private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
+  vpn_gateway_subnet_id            = dependency.common.outputs.vpn_gateway_subnet_id
 }

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -8,10 +8,11 @@ dependency "common" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    app_insights_connection_string   = "mock_connection_string"
-    app_insights_instrumentation_key = "mock_instrumentation_key"
-    app_service_plan_id              = "mock_id"
-    common_resource_group_name       = "mock_resource_group_name"
+    app_insights_connection_string              = "mock_connection_string"
+    app_insights_instrumentation_key            = "mock_instrumentation_key"
+    app_service_plan_id                         = "mock_id"
+    applications_service_vpn_gateway_shared_key = "mock_shared_key"
+    common_resource_group_name                  = "mock_resource_group_name"
     common_vnet_cidr_blocks = {
       app_gateway                    = "10.1.0.0/25"
       app_service_integration        = "10.1.1.0/24"
@@ -21,7 +22,6 @@ dependency "common" {
     }
     common_vnet_gateway_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworkGateways/mock_id"
     common_vnet_name       = "mock_vnet_name"
-    key_vault_name         = "mockkeyvaultname"
     key_vault_secret_refs = {
       applications-service-encryption-secret-key = "mock_secret"
       applications-service-mysql-host            = "mock_secret"
@@ -35,15 +35,15 @@ dependency "common" {
 }
 
 inputs = {
-  app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
-  app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
-  app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  common_resource_group_name       = dependency.common.outputs.common_resource_group_name
-  common_vnet_cidr_blocks          = dependency.common.outputs.common_vnet_cidr_blocks
-  common_vnet_gateway_id           = dependency.common.outputs.common_vnet_gateway_id
-  common_vnet_name                 = dependency.common.outputs.common_vnet_name
-  key_vault_name                   = dependency.common.outputs.key_vault_name
-  key_vault_secret_refs            = dependency.common.outputs.key_vault_secret_refs
-  integration_subnet_id            = dependency.common.outputs.integration_subnet_id
-  private_dns_zone_id              = dependency.common.outputs.private_dns_zone_id
+  app_insights_connection_string              = dependency.common.outputs.app_insights_connection_string
+  app_insights_instrumentation_key            = dependency.common.outputs.app_insights_instrumentation_key
+  app_service_plan_id                         = dependency.common.outputs.app_service_plan_id
+  applications_service_vpn_gateway_shared_key = dependency.common.outputs.applications_service_vpn_gateway_shared_key
+  common_resource_group_name                  = dependency.common.outputs.common_resource_group_name
+  common_vnet_cidr_blocks                     = dependency.common.outputs.common_vnet_cidr_blocks
+  common_vnet_gateway_id                      = dependency.common.outputs.common_vnet_gateway_id
+  common_vnet_name                            = dependency.common.outputs.common_vnet_name
+  key_vault_secret_refs                       = dependency.common.outputs.key_vault_secret_refs
+  integration_subnet_id                       = dependency.common.outputs.integration_subnet_id
+  private_dns_zone_id                         = dependency.common.outputs.private_dns_zone_id
 }

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -15,6 +15,12 @@ variable "app_insights_instrumentation_key" {
   type        = string
 }
 
+variable "applications_service_vpn_gateway_shared_key" {
+  description = "The applications service virtual network gateway shared key"
+  sensitive   = true
+  type        = string
+}
+
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
   type        = string
@@ -80,11 +86,6 @@ variable "logger_level" {
   description = "The level of logging enabled for applications in the environment e.g. info"
   type        = string
   default     = "info"
-}
-
-variable "key_vault_name" {
-  description = "The name of the common infrastructure key vault"
-  type        = string
 }
 
 variable "key_vault_secret_refs" {

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -98,6 +98,16 @@ variable "mysql_database" {
   type        = string
 }
 
+variable "national_infrastructure_gateway_ip" {
+  description = "The public IP address of the National Infrastructure gateway endpoint"
+  type        = string
+}
+
+variable "national_infrastructure_vnet_address_space" {
+  description = "The address space advertised by the National Infrastructure gateway endpoint"
+  type        = list(string)
+}
+
 variable "node_environment" {
   description = "The node environment to be used for applications in this environment e.g. development"
   type        = string

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -108,3 +108,8 @@ variable "tooling_subscription_id" {
   description = "The ID for the Tooling subscription that houses the Container Registry"
   type        = string
 }
+
+variable "vpn_gateway_subnet_id" {
+  description = "The id of the VPN gateway subnet"
+  type        = string
+}

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -82,6 +82,11 @@ variable "logger_level" {
   default     = "info"
 }
 
+variable "key_vault_name" {
+  description = "The name of the common infrastructure key vault"
+  type        = string
+}
+
 variable "key_vault_secret_refs" {
   description = "Map of secret references from the Key Vault"
   type        = map(string)

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -30,6 +30,11 @@ variable "common_vnet_cidr_blocks" {
   type        = map(string)
 }
 
+variable "common_vnet_gateway_id" {
+  description = "The id of the common infrastructure virtual network gateway"
+  type        = string
+}
+
 variable "common_vnet_name" {
   description = "The common infrastructure virtual network name"
   type        = string
@@ -106,10 +111,5 @@ variable "region" {
 
 variable "tooling_subscription_id" {
   description = "The ID for the Tooling subscription that houses the Container Registry"
-  type        = string
-}
-
-variable "vpn_gateway_subnet_id" {
-  description = "The id of the VPN gateway subnet"
   type        = string
 }

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -8,7 +8,7 @@ resource "azurerm_public_ip" "vpn_gateway" {
 
 resource "azurerm_virtual_network_gateway" "applications_service" {
   name                = "pins-vgw-${local.service_name}-${local.resource_suffix}"
-  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  resource_group_name = var.common_resource_group_name
   location            = azurerm_resource_group.applications_service_stack.location
   type                = "Vpn"
   vpn_type            = "RouteBased"

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -1,30 +1,3 @@
-resource "azurerm_public_ip" "vpn_gateway" {
-  name                = "pins-vgw-pip-${local.service_name}-${local.resource_suffix}"
-  resource_group_name = azurerm_resource_group.applications_service_stack.name
-  location            = azurerm_resource_group.applications_service_stack.location
-  allocation_method   = "Dynamic"
-  tags                = local.tags
-}
-
-resource "azurerm_virtual_network_gateway" "applications_service" {
-  name                = "pins-vgw-${local.service_name}-${local.resource_suffix}"
-  resource_group_name = var.common_resource_group_name
-  location            = azurerm_resource_group.applications_service_stack.location
-  type                = "Vpn"
-  vpn_type            = "RouteBased"
-  active_active       = false
-  enable_bgp          = false
-  sku                 = "VpnGw2"
-  tags                = local.tags
-
-  ip_configuration {
-    name                          = "Public"
-    public_ip_address_id          = azurerm_public_ip.vpn_gateway.id
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = var.vpn_gateway_subnet_id
-  }
-}
-
 resource "azurerm_local_network_gateway" "national_infrastructure" {
   name                = "pins-lgw-${local.service_name}-${local.resource_suffix}"
   resource_group_name = azurerm_resource_group.applications_service_stack.name
@@ -39,7 +12,7 @@ resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" 
   resource_group_name        = azurerm_resource_group.applications_service_stack.name
   location                   = azurerm_resource_group.applications_service_stack.location
   type                       = "IPsec"
-  virtual_network_gateway_id = azurerm_virtual_network_gateway.applications_service.id
+  virtual_network_gateway_id = var.common_vnet_gateway_id
   local_network_gateway_id   = azurerm_local_network_gateway.national_infrastructure.id
   shared_key                 = var.key_vault_secret_refs["applications-service-vpn-gateway-shared-key"]
   tags                       = local.tags

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -2,8 +2,8 @@ resource "azurerm_local_network_gateway" "national_infrastructure" {
   name                = "pins-lgw-${local.service_name}-${local.resource_suffix}"
   resource_group_name = azurerm_resource_group.applications_service_stack.name
   location            = azurerm_resource_group.applications_service_stack.location
-  gateway_address     = "51.104.42.155"
-  address_space       = ["10.222.0.0/26"]
+  gateway_address     = var.national_infrastructure_gateway_ip
+  address_space       = var.national_infrastructure_vnet_address_space
   tags                = local.tags
 }
 

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -41,9 +41,6 @@ resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" 
   type                       = "IPsec"
   virtual_network_gateway_id = azurerm_virtual_network_gateway.applications_service.id
   local_network_gateway_id   = azurerm_local_network_gateway.national_infrastructure.id
-  shared_key                 = "Testing"
+  shared_key                 = "Test" # var.key_vault_secret_refs["applications-service-vpn-gateway-shared-key"]
   tags                       = local.tags
-
-  # shared_key                 = data.azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key.value
-  # shared_key                 = "@Microsoft.KeyVault(SecretUri=${var.key_vault_uri}secrets/applications_service_vpn_gateway_shared_key)"
 }

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "vpn_gateway" {
   name                = "pins-vgw-pip-${local.service_name}-${local.resource_suffix}"
   resource_group_name = azurerm_resource_group.applications_service_stack.name
   location            = azurerm_resource_group.applications_service_stack.location
-  allocation_method   = "Static"
+  allocation_method   = "Dynamic"
   tags                = local.tags
 }
 

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -14,6 +14,6 @@ resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" 
   type                       = "IPsec"
   virtual_network_gateway_id = var.common_vnet_gateway_id
   local_network_gateway_id   = azurerm_local_network_gateway.national_infrastructure.id
-  shared_key                 = data.azurerm_key_vault_secret.vnet_gateway_shared_key.value
+  shared_key                 = var.applications_service_vpn_gateway_shared_key
   tags                       = local.tags
 }

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -41,6 +41,6 @@ resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" 
   type                       = "IPsec"
   virtual_network_gateway_id = azurerm_virtual_network_gateway.applications_service.id
   local_network_gateway_id   = azurerm_local_network_gateway.national_infrastructure.id
-  shared_key                 = "Test" # var.key_vault_secret_refs["applications-service-vpn-gateway-shared-key"]
+  shared_key                 = var.key_vault_secret_refs["applications-service-vpn-gateway-shared-key"]
   tags                       = local.tags
 }

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -1,0 +1,49 @@
+resource "azurerm_public_ip" "vpn_gateway" {
+  name                = "pins-vgw-pip-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  location            = azurerm_resource_group.applications_service_stack.location
+  allocation_method   = "Static"
+  tags                = local.tags
+}
+
+resource "azurerm_virtual_network_gateway" "applications_service" {
+  name                = "pins-vgw-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  location            = azurerm_resource_group.applications_service_stack.location
+  type                = "Vpn"
+  vpn_type            = "RouteBased"
+  active_active       = false
+  enable_bgp          = false
+  sku                 = "VpnGw2"
+  tags                = local.tags
+
+  ip_configuration {
+    name                          = "Public"
+    public_ip_address_id          = azurerm_public_ip.vpn_gateway.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = var.vpn_gateway_subnet_id
+  }
+}
+
+resource "azurerm_local_network_gateway" "national_infrastructure" {
+  name                = "pins-lgw-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  location            = azurerm_resource_group.applications_service_stack.location
+  gateway_address     = "51.104.42.155"
+  address_space       = ["10.222.0.0/26"]
+  tags                = local.tags
+}
+
+resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" {
+  name                       = "pins-vcn-${local.service_name}-${local.resource_suffix}"
+  resource_group_name        = azurerm_resource_group.applications_service_stack.name
+  location                   = azurerm_resource_group.applications_service_stack.location
+  type                       = "IPsec"
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.applications_service.id
+  local_network_gateway_id   = azurerm_local_network_gateway.national_infrastructure.id
+  shared_key                 = "Testing"
+  tags                       = local.tags
+
+  # shared_key                 = data.azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key.value
+  # shared_key                 = "@Microsoft.KeyVault(SecretUri=${var.key_vault_uri}secrets/applications_service_vpn_gateway_shared_key)"
+}

--- a/app/stacks/applications-service/vpn-gateway.tf
+++ b/app/stacks/applications-service/vpn-gateway.tf
@@ -14,6 +14,6 @@ resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" 
   type                       = "IPsec"
   virtual_network_gateway_id = var.common_vnet_gateway_id
   local_network_gateway_id   = azurerm_local_network_gateway.national_infrastructure.id
-  shared_key                 = var.key_vault_secret_refs["applications-service-vpn-gateway-shared-key"]
+  shared_key                 = data.azurerm_key_vault_secret.vnet_gateway_shared_key.value
   tags                       = local.tags
 }

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -61,6 +61,7 @@ No requirements.
 | <a name="output_common_vnet_gateway_id"></a> [common\_vnet\_gateway\_id](#output\_common\_vnet\_gateway\_id) | The id of the common infrastructure virtual network gateway |
 | <a name="output_common_vnet_name"></a> [common\_vnet\_name](#output\_common\_vnet\_name) | The name of the common infrastructure virtual network |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
+| <a name="output_key_vault_name"></a> [key\_vault\_name](#output\_key\_vault\_name) | The name of the common infrastructure key vault |
 | <a name="output_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#output\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -39,6 +39,7 @@ No requirements.
 | [azurerm_virtual_network.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_gateway.common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 
 ## Inputs
 

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -27,6 +27,7 @@ No requirements.
 | [azurerm_app_service_plan.common_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_plan) | resource |
 | [azurerm_application_insights.node](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_key_vault.environment_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
+| [azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_dns_zone.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
@@ -56,12 +57,12 @@ No requirements.
 | <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
 | <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
+| <a name="output_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#output\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key |
 | <a name="output_common_resource_group_name"></a> [common\_resource\_group\_name](#output\_common\_resource\_group\_name) | The name of the common infrastructure resource group |
 | <a name="output_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#output\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix |
 | <a name="output_common_vnet_gateway_id"></a> [common\_vnet\_gateway\_id](#output\_common\_vnet\_gateway\_id) | The id of the common infrastructure virtual network gateway |
 | <a name="output_common_vnet_name"></a> [common\_vnet\_name](#output\_common\_vnet\_name) | The name of the common infrastructure virtual network |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
-| <a name="output_key_vault_name"></a> [key\_vault\_name](#output\_key\_vault\_name) | The name of the common infrastructure key vault |
 | <a name="output_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#output\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -30,11 +30,13 @@ No requirements.
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_dns_zone.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_public_ip.vnet_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.app_gateway_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.integration_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-| [azurerm_subnet.vpn_gateway_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.vnet_gateway_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_gateway.common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
@@ -56,9 +58,9 @@ No requirements.
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
 | <a name="output_common_resource_group_name"></a> [common\_resource\_group\_name](#output\_common\_resource\_group\_name) | The name of the common infrastructure resource group |
 | <a name="output_common_vnet_cidr_blocks"></a> [common\_vnet\_cidr\_blocks](#output\_common\_vnet\_cidr\_blocks) | A map of IP address blocks from the subnet name to the allocated CIDR prefix |
+| <a name="output_common_vnet_gateway_id"></a> [common\_vnet\_gateway\_id](#output\_common\_vnet\_gateway\_id) | The id of the common infrastructure virtual network gateway |
 | <a name="output_common_vnet_name"></a> [common\_vnet\_name](#output\_common\_vnet\_name) | The name of the common infrastructure virtual network |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
 | <a name="output_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#output\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
-| <a name="output_vpn_gateway_subnet_id"></a> [vpn\_gateway\_subnet\_id](#output\_vpn\_gateway\_subnet\_id) | The id of the VPN gateway subnet |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -60,4 +60,5 @@ No requirements.
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
 | <a name="output_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#output\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault |
 | <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | The id of the private DNS zone for App services |
+| <a name="output_vpn_gateway_subnet_id"></a> [vpn\_gateway\_subnet\_id](#output\_vpn\_gateway\_subnet\_id) | The id of the VPN gateway subnet |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/address-space.tf
+++ b/app/stacks/common/address-space.tf
@@ -8,7 +8,7 @@ module "common_vnet_address_space" {
       new_bits = 9 # /25 (123 usable) [0 - 127]
     },
     {
-      name     = "vpn_gateway"
+      name     = "vnet_gateway"
       new_bits = 9 # /25 (123 usable) [128 - 255]
     },
     {

--- a/app/stacks/common/data.tf
+++ b/app/stacks/common/data.tf
@@ -1,1 +1,6 @@
 data "azurerm_client_config" "current" {}
+
+data "azurerm_key_vault_secret" "applications_service_vpn_gateway_shared_key" {
+  name         = azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key.name
+  key_vault_id = azurerm_key_vault.environment_key_vault.id
+}

--- a/app/stacks/common/key-vault.tf
+++ b/app/stacks/common/key-vault.tf
@@ -16,15 +16,15 @@ resource "azurerm_key_vault" "environment_key_vault" {
     object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
-      "Create", "Delete", "Get", "List"
+      "Create", "Delete", "Get", "List", "Purge"
     ]
 
     secret_permissions = [
-      "Delete", "Get", "List", "Set"
+      "Delete", "Get", "List", "Set", "Purge"
     ]
 
     storage_permissions = [
-      "Delete", "Get", "List", "Set"
+      "Delete", "Get", "List", "Set", "Purge"
     ]
   }
 

--- a/app/stacks/common/key-vault.tf
+++ b/app/stacks/common/key-vault.tf
@@ -16,15 +16,15 @@ resource "azurerm_key_vault" "environment_key_vault" {
     object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
-      "Create", "Delete", "Get", "List", "Purge"
+      "Create", "Delete", "Get", "List", "Purge", "Recover"
     ]
 
     secret_permissions = [
-      "Delete", "Get", "List", "Set", "Purge"
+      "Delete", "Get", "List", "Set", "Purge", "Recover"
     ]
 
     storage_permissions = [
-      "Delete", "Get", "List", "Set", "Purge"
+      "Delete", "Get", "List", "Set", "Purge", "Recover"
     ]
   }
 

--- a/app/stacks/common/key-vault.tf
+++ b/app/stacks/common/key-vault.tf
@@ -28,6 +28,23 @@ resource "azurerm_key_vault" "environment_key_vault" {
     ]
   }
 
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = "6e0b1ad0-76db-4871-b8d8-9d7b539527ff" # "PINS ODT Key Vault Admins"
+
+    key_permissions = [
+      "Create", "Get", "List"
+    ]
+
+    secret_permissions = [
+      "Get", "List", "Set"
+    ]
+
+    storage_permissions = [
+      "Get", "List", "Set"
+    ]
+  }
+
   tags = local.tags
 }
 

--- a/app/stacks/common/key-vault.tf
+++ b/app/stacks/common/key-vault.tf
@@ -48,6 +48,23 @@ resource "azurerm_key_vault" "environment_key_vault" {
   tags = local.tags
 }
 
+resource "azurerm_key_vault_secret" "applications_service_vpn_gateway_shared_key" {
+  #checkov:skip=CKV_AZURE_41: TODO: Secret rotation
+  #checkov:skip=CKV_AZURE_114: No need to set content type via Terraform, as secrets to be updated in Portal
+  key_vault_id = azurerm_key_vault.environment_key_vault.id
+  name         = "applications-service-vpn-gateway-shared-key"
+  value        = "<enter_value>"
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [
+      value,
+      version
+    ]
+  }
+}
+
 resource "azurerm_key_vault_secret" "secret" {
   #checkov:skip=CKV_AZURE_41: TODO: Secret rotation
   #checkov:skip=CKV_AZURE_114: No need to set content type via Terraform, as secrets to be updated in Portal

--- a/app/stacks/common/locals.tf
+++ b/app/stacks/common/locals.tf
@@ -13,7 +13,6 @@ locals {
     "applications-service-mysql-host",
     "applications-service-mysql-password",
     "applications-service-mysql-username",
-    "applications-service-vpn-gateway-shared-key",
     "srv-notify-api-key"
   ]
 

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -13,7 +13,7 @@ resource "azurerm_subnet" "app_gateway_subnet" {
 }
 
 resource "azurerm_subnet" "vpn_gateway_subnet" {
-  name                 = "pins-snet-${local.service_name}-vpn-${local.resource_suffix}"
+  name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
   virtual_network_name = azurerm_virtual_network.common_infrastructure.name
   address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["vpn_gateway"]]

--- a/app/stacks/common/network.tf
+++ b/app/stacks/common/network.tf
@@ -12,11 +12,11 @@ resource "azurerm_subnet" "app_gateway_subnet" {
   address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["app_gateway"]]
 }
 
-resource "azurerm_subnet" "vpn_gateway_subnet" {
+resource "azurerm_subnet" "vnet_gateway_subnet" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.common_infrastructure.name
   virtual_network_name = azurerm_virtual_network.common_infrastructure.name
-  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["vpn_gateway"]]
+  address_prefixes     = [module.common_vnet_address_space.network_cidr_blocks["vnet_gateway"]]
 }
 
 resource "azurerm_subnet" "integration_subnet" {

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -40,6 +40,11 @@ output "integration_subnet_id" {
   value       = azurerm_subnet.integration_subnet.id
 }
 
+output "key_vault_name" {
+  description = "The name of the common infrastructure key vault"
+  value       = azurerm_key_vault.environment_key_vault.name
+}
+
 output "key_vault_secret_refs" {
   description = "Map of secret references from the Key Vault"
   value       = local.secret_refs

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -25,6 +25,11 @@ output "common_vnet_cidr_blocks" {
   value       = module.common_vnet_address_space.network_cidr_blocks
 }
 
+output "common_vnet_gateway_id" {
+  description = "The id of the common infrastructure virtual network gateway"
+  value       = azurerm_virtual_network_gateway.common.id
+}
+
 output "common_vnet_name" {
   description = "The name of the common infrastructure virtual network"
   value       = azurerm_virtual_network.common_infrastructure.name
@@ -43,9 +48,4 @@ output "key_vault_secret_refs" {
 output "private_dns_zone_id" {
   description = "The id of the private DNS zone for App services"
   value       = azurerm_private_dns_zone.private_link.id
-}
-
-output "vpn_gateway_subnet_id" {
-  description = "The id of the VPN gateway subnet"
-  value       = azurerm_subnet.vpn_gateway_subnet.id
 }

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -44,3 +44,8 @@ output "private_dns_zone_id" {
   description = "The id of the private DNS zone for App services"
   value       = azurerm_private_dns_zone.private_link.id
 }
+
+output "vpn_gateway_subnet_id" {
+  description = "The id of the VPN gateway subnet"
+  value       = azurerm_subnet.vpn_gateway_subnet.id
+}

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -15,6 +15,12 @@ output "app_service_plan_id" {
   value       = azurerm_app_service_plan.common_service_plan.id
 }
 
+output "applications_service_vpn_gateway_shared_key" {
+  description = "The applications service virtual network gateway shared key"
+  sensitive   = true
+  value       = azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key.value
+}
+
 output "common_resource_group_name" {
   description = "The name of the common infrastructure resource group"
   value       = azurerm_resource_group.common_infrastructure.name
@@ -38,11 +44,6 @@ output "common_vnet_name" {
 output "integration_subnet_id" {
   description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   value       = azurerm_subnet.integration_subnet.id
-}
-
-output "key_vault_name" {
-  description = "The name of the common infrastructure key vault"
-  value       = azurerm_key_vault.environment_key_vault.name
 }
 
 output "key_vault_secret_refs" {

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -18,7 +18,7 @@ output "app_service_plan_id" {
 output "applications_service_vpn_gateway_shared_key" {
   description = "The applications service virtual network gateway shared key"
   sensitive   = true
-  value       = azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key.value
+  value       = data.azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key.value
 }
 
 output "common_resource_group_name" {

--- a/app/stacks/common/vpn-gateway.tf
+++ b/app/stacks/common/vpn-gateway.tf
@@ -1,0 +1,26 @@
+resource "azurerm_public_ip" "vnet_gateway" {
+  name                = "pins-vgw-pip-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.common_infrastructure.name
+  location            = azurerm_resource_group.common_infrastructure.location
+  allocation_method   = "Dynamic"
+  tags                = local.tags
+}
+
+resource "azurerm_virtual_network_gateway" "common" {
+  name                = "pins-vgw-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.common_infrastructure.name
+  location            = azurerm_resource_group.common_infrastructure.location
+  type                = "Vpn"
+  vpn_type            = "RouteBased"
+  active_active       = false
+  enable_bgp          = false
+  sku                 = "VpnGw2"
+  tags                = local.tags
+
+  ip_configuration {
+    name                          = "Public"
+    public_ip_address_id          = azurerm_public_ip.vnet_gateway.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.vnet_gateway_subnet.id
+  }
+}

--- a/config/variables/dev.hcl
+++ b/config/variables/dev.hcl
@@ -1,6 +1,8 @@
 locals {
-  api_timeout               = 10000
-  environment               = "dev"
-  common_vnet_address_space = "10.1.0.0/16"
-  google_analytics_id       = "G-X21W2S2FN3"
+  api_timeout                                = 10000
+  environment                                = "dev"
+  common_vnet_address_space                  = "10.1.0.0/16"
+  google_analytics_id                        = "G-X21W2S2FN3"
+  national_infrastructure_gateway_ip         = "51.104.42.155"
+  national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
 }

--- a/config/variables/prod.hcl
+++ b/config/variables/prod.hcl
@@ -1,8 +1,10 @@
 locals {
-  api_timeout               = 10000
-  environment               = "prod"
-  common_vnet_address_space = "10.3.0.0/16"
-  logger_level              = "info"
-  node_environment          = "production"
-  google_analytics_id       = "tbc"
+  api_timeout                                = 10000
+  environment                                = "prod"
+  common_vnet_address_space                  = "10.3.0.0/16"
+  logger_level                               = "info"
+  node_environment                           = "production"
+  google_analytics_id                        = "tbc"
+  national_infrastructure_gateway_ip         = "51.104.42.155"
+  national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
 }

--- a/config/variables/test.hcl
+++ b/config/variables/test.hcl
@@ -1,6 +1,8 @@
 locals {
-  api_timeout               = 10000
-  environment               = "test"
-  common_vnet_address_space = "10.2.0.0/16"
-  google_analytics_id       = "G-X21W2S2FN3"
+  api_timeout                                = 10000
+  environment                                = "test"
+  common_vnet_address_space                  = "10.2.0.0/16"
+  google_analytics_id                        = "G-X21W2S2FN3"
+  national_infrastructure_gateway_ip         = "51.104.42.155"
+  national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
 }


### PR DESCRIPTION
- Adds a virtual network gateway to the common stack with AppGateway subnet.
- Adds a local network gateway and site-to-site VPN connection to the Applications Service stack.
- Integrates with the common key vault to retrieve the shared key for VPN connection encryption.