### PR TITLE
Initial Front Door deployment with frontend app service restrictions

### DIFF
--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -30,6 +30,16 @@ resource "azurerm_app_service" "app_service" {
     always_on     = "true"
     ftps_state    = "FtpsOnly"
     http2_enabled = true
+
+    dynamic "ip_restriction" {
+      for_each = var.inbound_vnet_connectivity == false ? [1] : []
+      content {
+        name        = "FrontDoorInbound"
+        service_tag = "AzureFrontDoor.Backend"
+        action      = "Allow"
+        priority    = 100
+      }
+    }
   }
 
   app_settings = merge(

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -33,6 +33,7 @@ resource "azurerm_app_service" "app_service" {
 
     dynamic "ip_restriction" {
       for_each = var.inbound_vnet_connectivity == false ? [1] : []
+
       content {
         name        = "FrontDoorInbound"
         service_tag = "AzureFrontDoor.Backend"

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -63,5 +63,7 @@ No requirements.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_national_infrastructure_frontend_url"></a> [national\_infrastructure\_frontend\_url](#output\_national\_infrastructure\_frontend\_url) | The URL of the applications service national infrastructure frontend app service |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -65,5 +65,5 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_ni_frontend_url"></a> [ni\_frontend\_url](#output\_ni\_frontend\_url) | The URL of the applications service national infrastructure frontend app service |
+| <a name="output_app_service_urls"></a> [app\_service\_urls](#output\_app\_service\_urls) | A map of frontend app service URLs |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -65,5 +65,5 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_national_infrastructure_frontend_url"></a> [national\_infrastructure\_frontend\_url](#output\_national\_infrastructure\_frontend\_url) | The URL of the applications service national infrastructure frontend app service |
+| <a name="output_ni_frontend_url"></a> [ni\_frontend\_url](#output\_ni\_frontend\_url) | The URL of the applications service national infrastructure frontend app service |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/applications-service/outputs.tf
+++ b/app/stacks/applications-service/outputs.tf
@@ -1,0 +1,4 @@
+output "national_infrastructure_frontend_url" {
+  description = "The URL of the applications service national infrastructure frontend app service"
+  value       = module.national_infrastructure_frontend.default_site_hostname
+}

--- a/app/stacks/applications-service/outputs.tf
+++ b/app/stacks/applications-service/outputs.tf
@@ -1,4 +1,6 @@
-output "ni_frontend_url" {
-  description = "The URL of the applications service national infrastructure frontend app service"
-  value       = module.national_infrastructure_frontend.default_site_hostname
+output "app_service_urls" {
+  description = "A map of frontend app service URLs"
+  value = {
+    national_infrastructure_frontend = module.national_infrastructure_frontend.default_site_hostname
+  }
 }

--- a/app/stacks/applications-service/outputs.tf
+++ b/app/stacks/applications-service/outputs.tf
@@ -1,4 +1,4 @@
-output "national_infrastructure_frontend_url" {
+output "ni_frontend_url" {
   description = "The URL of the applications service national infrastructure frontend app service"
   value       = module.national_infrastructure_frontend.default_site_hostname
 }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -46,7 +46,7 @@ resource "azurerm_frontdoor" "common" {
       host_header = "www.gov.uk/government/organisations/planning-inspectorate"
       http_port   = 80
       https_port  = 443
-      priority    = 100
+      priority    = 5
       weight      = 100
     }
   }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -1,4 +1,7 @@
 resource "azurerm_frontdoor" "common" {
+  #TODO: Add frontend endpoints for custom domains:
+  # - Applications: www.national-infrastructure.planninginspectorate.gov.uk
+  # - Appeals:      appeal-planning-decision.planninginspectorate.gov.uk
   #checkov:skip=CKV_AZURE_121: WAF to be implemented later
   name                                         = "pins-fd-${local.service_name}-${local.resource_suffix}"
   resource_group_name                          = var.common_resource_group_name
@@ -54,9 +57,10 @@ resource "azurerm_frontdoor" "common" {
     frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
     forwarding_configuration {
-      backend_pool_name   = "NationalInfrastructureFrontend"
-      cache_enabled       = false
-      forwarding_protocol = "MatchRequest"
+      backend_pool_name      = "NationalInfrastructureFrontend"
+      cache_enabled          = false
+      cache_query_parameters = []
+      forwarding_protocol    = "MatchRequest"
     }
   }
 }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -67,7 +67,7 @@ resource "azurerm_frontdoor" "common" {
   }
 
   #========================================================================
-  # Applications Service Frontend Endpoint
+  # Dynamic Service Frontend Endpoints
   #========================================================================
 
   dynamic "frontend_endpoint" {

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -50,7 +50,7 @@ resource "azurerm_frontdoor" "common" {
     name               = "ForwardHttps"
     accepted_protocols = ["Http", "Https"]
     patterns_to_match  = ["/*"]
-    frontend_endpoints = ["NationalInfrastructure"]
+    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
     forwarding_configuration {
       backend_pool_name   = "NationalInfrastructureFrontend"

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -111,7 +111,7 @@ resource "azurerm_frontdoor" "common" {
       frontend_endpoints = [mapping.value["name"]]
 
       forwarding_configuration {
-        backend_pool_name      = "Default"
+        backend_pool_name      = mapping.value["name"]
         cache_enabled          = false
         cache_query_parameters = []
         forwarding_protocol    = "MatchRequest"

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -1,0 +1,57 @@
+resource "azurerm_frontdoor" "common" {
+  #checkov:skip=CKV_AZURE_121: WAF to be implemented later
+  name                                         = "pins-fd-${local.service_name}-${local.resource_suffix}"
+  resource_group_name                          = var.common_resource_group_name
+  enforce_backend_pools_certificate_name_check = false
+  tags                                         = local.tags
+
+  frontend_endpoint {
+    name      = "NationalInfrastructure"
+    host_name = var.environment == "prod" ? "pins-odt-ni-wfe.azurefd.net" : "pins-odt-ni-wfe-${var.environment}.azurefd.net"
+
+    # web_application_firewall_policy_link_id
+  }
+
+  backend_pool_load_balancing {
+    name = "Default"
+  }
+
+  backend_pool_health_probe {
+    name = "Http"
+  }
+
+  backend_pool {
+    name                = "NationalInfrastructureFrontend"
+    load_balancing_name = "Default"
+    health_probe_name   = "Http"
+
+    backend {
+      address     = var.national_infrastructure_frontend_url
+      host_header = var.national_infrastructure_frontend_url
+      http_port   = 80
+      https_port  = 443
+    }
+  }
+
+  routing_rule {
+    name               = "ForwardHttps"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["NationalInfrastructure"]
+
+    forwarding_configuration {
+      backend_pool_name = "NationalInfrastructureFrontend"
+    }
+  }
+}
+
+# resource "azurerm_frontdoor_custom_https_configuration" "applications_service" {
+#   frontend_endpoint_id              = azurerm_frontdoor.common.id
+#   custom_https_provisioning_enabled = true
+
+#   custom_https_configuration {
+#     certificate_source                      = "AzureKeyVault"
+#     azure_key_vault_certificate_secret_name = "applications-service-${var.environment}"
+#     azure_key_vault_certificate_vault_id    = azurerm_key_vault.environment_key_vault.id
+#   }
+# }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -12,8 +12,6 @@ resource "azurerm_frontdoor" "common" {
     name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
     host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
 
-    # host_name = "${local.ni_frontend_prefix}.azurefd.net"
-    # host_name = var.environment == "prod" ? "${local.ni_frontend_prefix}.azurefd.net" : "${local.ni_frontend_prefix}-${var.environment}.azurefd.net"
     # web_application_firewall_policy_link_id
   }
 

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -56,7 +56,7 @@ resource "azurerm_frontdoor" "common" {
     name               = "ForwardHttps"
     accepted_protocols = ["Http", "Https"]
     patterns_to_match  = ["/*"]
-    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
+    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"]
 
     forwarding_configuration {
       backend_pool_name      = "Default"

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -74,6 +74,7 @@ resource "azurerm_frontdoor" "common" {
   dynamic "frontend_endpoint" {
     for_each = local.frontend_mappings
     iterator = mapping
+
     content {
       name      = mapping.value["name"]
       host_name = mapping.value["frontend_endpoint"]
@@ -83,6 +84,7 @@ resource "azurerm_frontdoor" "common" {
   dynamic "backend_pool" {
     for_each = local.frontend_mappings
     iterator = mapping
+
     content {
       name                = mapping.value["name"]
       load_balancing_name = "Default"
@@ -103,6 +105,7 @@ resource "azurerm_frontdoor" "common" {
   dynamic "routing_rule" {
     for_each = local.frontend_mappings
     iterator = mapping
+
     content {
       enabled            = true
       name               = mapping.value["name"]

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -7,7 +7,7 @@ resource "azurerm_frontdoor" "common" {
 
   frontend_endpoint {
     name      = "NationalInfrastructure"
-    host_name = var.environment == "prod" ? "pins-odt-ni-wfe.azurefd.net" : "pins-odt-ni-wfe-${var.environment}.azurefd.net"
+    host_name = var.environment == "prod" ? "${local.ni_frontend_prefix}.azurefd.net" : "${local.ni_frontend_prefix}-${var.environment}.azurefd.net"
 
     # web_application_firewall_policy_link_id
   }
@@ -26,8 +26,8 @@ resource "azurerm_frontdoor" "common" {
     health_probe_name   = "Http"
 
     backend {
-      address     = var.national_infrastructure_frontend_url
-      host_header = var.national_infrastructure_frontend_url
+      address     = var.ni_frontend_url
+      host_header = var.ni_frontend_url
       http_port   = 80
       https_port  = 443
     }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -7,8 +7,9 @@ resource "azurerm_frontdoor" "common" {
 
   frontend_endpoint {
     name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
-    host_name = "${local.ni_frontend_prefix}.azurefd.net"
+    host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
 
+    # host_name = "${local.ni_frontend_prefix}.azurefd.net"
     # host_name = var.environment == "prod" ? "${local.ni_frontend_prefix}.azurefd.net" : "${local.ni_frontend_prefix}-${var.environment}.azurefd.net"
     # web_application_firewall_policy_link_id
   }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -42,8 +42,8 @@ resource "azurerm_frontdoor" "common" {
 
     backend {
       enabled     = true
-      address     = "www.gov.uk/government/organisations/planning-inspectorate"
-      host_header = "www.gov.uk/government/organisations/planning-inspectorate"
+      address     = "www.gov.uk"
+      host_header = "www.gov.uk"
       http_port   = 80
       https_port  = 443
       priority    = 5
@@ -55,13 +55,14 @@ resource "azurerm_frontdoor" "common" {
     enabled            = true
     name               = "ForwardHttps"
     accepted_protocols = ["Http", "Https"]
-    patterns_to_match  = ["/*"]
+    patterns_to_match  = ["/"]
     frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
     forwarding_configuration {
       backend_pool_name      = "Default"
       cache_enabled          = false
       cache_query_parameters = []
+      custom_forwarding_path = "/government/organisations/planning-inspectorate"
       forwarding_protocol    = "MatchRequest"
     }
   }
@@ -70,14 +71,14 @@ resource "azurerm_frontdoor" "common" {
   # Dynamic Service Frontend Endpoints
   #========================================================================
 
-  dynamic "frontend_endpoint" {
-    for_each = local.frontend_mappings
-    iterator = mapping
-    content {
-      name      = mapping.value["name"]
-      host_name = mapping.value["frontend_endpoint"]
-    }
-  }
+  # dynamic "frontend_endpoint" {
+  #   for_each = local.frontend_mappings
+  #   iterator = mapping
+  #   content {
+  #     name      = mapping.value["name"]
+  #     host_name = mapping.value["frontend_endpoint"]
+  #   }
+  # }
 
   dynamic "backend_pool" {
     for_each = local.frontend_mappings

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -107,7 +107,7 @@ resource "azurerm_frontdoor" "common" {
       name               = "ForwardHttps"
       accepted_protocols = ["Http", "Https"]
       patterns_to_match  = mapping.value["patterns_to_match"]
-      frontend_endpoints = ["www.national-infrastructure.planninginspectorate.gov.uk"]
+      frontend_endpoints = [mapping.value["frontend_endpoint"]]
 
       forwarding_configuration {
         backend_pool_name      = "Default"

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -71,20 +71,20 @@ resource "azurerm_frontdoor" "common" {
   # Dynamic Service Frontend Endpoints
   #========================================================================
 
-  # dynamic "frontend_endpoint" {
-  #   for_each = local.frontend_mappings
-  #   iterator = mapping
-  #   content {
-  #     name      = mapping.value["name"]
-  #     host_name = mapping.value["frontend_endpoint"]
-  #   }
-  # }
+  dynamic "frontend_endpoint" {
+    for_each = local.frontend_mappings
+    iterator = mapping
+    content {
+      name      = mapping.value["name"]
+      host_name = mapping.value["frontend_endpoint"]
+    }
+  }
 
   dynamic "backend_pool" {
     for_each = local.frontend_mappings
     iterator = mapping
     content {
-      name                = "Default"
+      name                = mapping.value["name"]
       load_balancing_name = "Default"
       health_probe_name   = "Http"
 
@@ -105,7 +105,7 @@ resource "azurerm_frontdoor" "common" {
     iterator = mapping
     content {
       enabled            = true
-      name               = "ForwardHttps"
+      name               = mapping.value["name"]
       accepted_protocols = ["Http", "Https"]
       patterns_to_match  = mapping.value["patterns_to_match"]
       frontend_endpoints = [mapping.value["name"]]

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -56,7 +56,7 @@ resource "azurerm_frontdoor" "common" {
     name               = "ForwardHttps"
     accepted_protocols = ["Http", "Https"]
     patterns_to_match  = ["/*"]
-    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"]
+    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
     forwarding_configuration {
       backend_pool_name      = "Default"
@@ -107,7 +107,7 @@ resource "azurerm_frontdoor" "common" {
       name               = "ForwardHttps"
       accepted_protocols = ["Http", "Https"]
       patterns_to_match  = mapping.value["patterns_to_match"]
-      frontend_endpoints = [mapping.value["frontend_endpoint"]]
+      frontend_endpoints = [mapping.value["name"]]
 
       forwarding_configuration {
         backend_pool_name      = "Default"

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -13,11 +13,19 @@ resource "azurerm_frontdoor" "common" {
   }
 
   backend_pool_load_balancing {
-    name = "Default"
+    name                            = "Default"
+    sample_size                     = 4
+    successful_samples_required     = 2
+    additional_latency_milliseconds = 0
   }
 
   backend_pool_health_probe {
-    name = "Http"
+    enabled             = true
+    name                = "Http"
+    path                = "/"
+    protocol            = "Http"
+    probe_method        = "GET"
+    interval_in_seconds = 120
   }
 
   backend_pool {
@@ -26,21 +34,27 @@ resource "azurerm_frontdoor" "common" {
     health_probe_name   = "Http"
 
     backend {
+      enabled     = true
       address     = var.ni_frontend_url
       host_header = var.ni_frontend_url
       http_port   = 80
       https_port  = 443
+      priority    = 1
+      weight      = 100
     }
   }
 
   routing_rule {
+    enabled            = true
     name               = "ForwardHttps"
     accepted_protocols = ["Http", "Https"]
     patterns_to_match  = ["/*"]
     frontend_endpoints = ["NationalInfrastructure"]
 
     forwarding_configuration {
-      backend_pool_name = "NationalInfrastructureFrontend"
+      backend_pool_name   = "NationalInfrastructureFrontend"
+      cache_enabled       = false
+      forwarding_protocol = "MatchRequest"
     }
   }
 }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -28,44 +28,44 @@ resource "azurerm_frontdoor" "common" {
   # Default Frontend Endpoint
   #========================================================================
 
-  frontend_endpoint {
-    name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
-    host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
+  # frontend_endpoint {
+  #   name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
+  #   host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
 
-    # web_application_firewall_policy_link_id
-  }
+  #   # web_application_firewall_policy_link_id
+  # }
 
-  backend_pool {
-    name                = "Default"
-    load_balancing_name = "Default"
-    health_probe_name   = "Http"
+  # backend_pool {
+  #   name                = "Default"
+  #   load_balancing_name = "Default"
+  #   health_probe_name   = "Http"
 
-    backend {
-      enabled     = true
-      address     = "www.gov.uk"
-      host_header = "www.gov.uk"
-      http_port   = 80
-      https_port  = 443
-      priority    = 5
-      weight      = 100
-    }
-  }
+  #   backend {
+  #     enabled     = true
+  #     address     = "www.gov.uk"
+  #     host_header = "www.gov.uk"
+  #     http_port   = 80
+  #     https_port  = 443
+  #     priority    = 5
+  #     weight      = 100
+  #   }
+  # }
 
-  routing_rule {
-    enabled            = true
-    name               = "ForwardHttps"
-    accepted_protocols = ["Http", "Https"]
-    patterns_to_match  = ["/"]
-    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
+  # routing_rule {
+  #   enabled            = true
+  #   name               = "ForwardHttps"
+  #   accepted_protocols = ["Http", "Https"]
+  #   patterns_to_match  = ["/"]
+  #   frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
-    forwarding_configuration {
-      backend_pool_name      = "Default"
-      cache_enabled          = false
-      cache_query_parameters = []
-      custom_forwarding_path = "/government/organisations/planning-inspectorate"
-      forwarding_protocol    = "MatchRequest"
-    }
-  }
+  #   forwarding_configuration {
+  #     backend_pool_name      = "Default"
+  #     cache_enabled          = false
+  #     cache_query_parameters = []
+  #     custom_forwarding_path = "/government/organisations/planning-inspectorate"
+  #     forwarding_protocol    = "MatchRequest"
+  #   }
+  # }
 
   #========================================================================
   # Dynamic Service Frontend Endpoints

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -6,9 +6,10 @@ resource "azurerm_frontdoor" "common" {
   tags                                         = local.tags
 
   frontend_endpoint {
-    name      = "NationalInfrastructure"
-    host_name = var.environment == "prod" ? "${local.ni_frontend_prefix}.azurefd.net" : "${local.ni_frontend_prefix}-${var.environment}.azurefd.net"
+    name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
+    host_name = "${local.ni_frontend_prefix}.azurefd.net"
 
+    # host_name = var.environment == "prod" ? "${local.ni_frontend_prefix}.azurefd.net" : "${local.ni_frontend_prefix}-${var.environment}.azurefd.net"
     # web_application_firewall_policy_link_id
   }
 

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,7 +1,7 @@
 locals {
   frontend_mappings = {
     national_infrastructure_frontend = {
-      name              = "www.national-infrastructure.planninginspectorate.gov.uk"
+      name              = "NationalInfrastructure"
       frontend_endpoint = "www.national-infrastructure.planninginspectorate.gov.uk"
       patterns_to_match = ["/*"]
     }

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,7 +1,8 @@
 locals {
-  ni_frontend_prefix = split(".azurewebsites.net", var.ni_frontend_url)[0]
-  service_name       = "front-door"
-  resource_suffix    = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
+  # ni_frontend_prefix = split(".azurewebsites.net", var.ni_frontend_url)[0]
+
+  service_name    = "front-door"
+  resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
   tags = merge(
     var.common_tags,
     {

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,8 +1,8 @@
 locals {
   frontend_mappings = {
     national_infrastructure_frontend = {
-      name              = "NationalInfrastructure"
-      frontend_endpoint = "www.national-infrastructure.planninginspectorate.gov.uk"
+      name              = "pins-fd-${local.service_name}-${local.resource_suffix}"
+      frontend_endpoint = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
       patterns_to_match = ["/*"]
     }
   }

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  frontend_mappings = {
+    national_infrastructure_frontend = {
+      name              = "pins-fd-${local.service_name}-${local.resource_suffix}"
+      frontend_endpoint = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
+      patterns_to_match = ["/ni-wfe"]
+    }
+  }
   service_name    = "front-door"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
   tags = merge(

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  service_name    = "front-door"
-  resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
+  ni_frontend_prefix = split(".azurewebsites.net", var.ni_frontend_url)[0]
+  service_name       = "front-door"
+  resource_suffix    = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
   tags = merge(
     var.common_tags,
     {

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,9 +1,9 @@
 locals {
   frontend_mappings = {
     national_infrastructure_frontend = {
-      name              = "pins-fd-${local.service_name}-${local.resource_suffix}"
-      frontend_endpoint = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
-      patterns_to_match = ["/ni-wfe"]
+      name              = "www.national-infrastructure.planninginspectorate.gov.uk"
+      frontend_endpoint = "www.national-infrastructure.planninginspectorate.gov.uk"
+      patterns_to_match = ["/*"]
     }
   }
   service_name    = "front-door"

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  service_name    = "front-door"
+  resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
+  tags = merge(
+    var.common_tags,
+    {
+      Region = var.region
+    }
+  )
+}

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  # ni_frontend_prefix = split(".azurewebsites.net", var.ni_frontend_url)[0]
-
   service_name    = "front-door"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
   tags = merge(

--- a/app/stacks/front-door/region.tf
+++ b/app/stacks/front-door/region.tf
@@ -1,0 +1,6 @@
+module "azure_region_uks" {
+  source  = "claranet/regions/azurerm"
+  version = "4.2.1"
+
+  azure_region = var.region
+}

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "applications_service" {
 
   mock_outputs = {
     app_service_urls = {
-      mock_app_service = mock_url
+      mock_app_service = "mock_url"
     }
   }
 }

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -12,17 +12,19 @@ dependency "common" {
   }
 }
 
-dependency "applications-service" {
+dependency "applications_service" {
   config_path                             = "../applications-service"
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    ni_frontend_url = "mock-app-service.azurewebsites.net"
+    app_service_urls = {
+      mock_app_service = mock_url
+    }
   }
 }
 
 inputs = {
+  app_service_urls           = dependency.applications_service.outputs.app_service_urls
   common_resource_group_name = dependency.common.outputs.common_resource_group_name
-  ni_frontend_url            = dependency.applications-service.outputs.ni_frontend_url
 }

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "applications_service" {
 
   mock_outputs = {
     app_service_urls = {
-      mock_app_service = "mock_url"
+      national_infrastructure_frontend = "mock_url"
     }
   }
 }

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -18,11 +18,11 @@ dependency "applications-service" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    national_infrastructure_frontend_url = "https://mock-app-service.azurewebsites.net"
+    ni_frontend_url = "mock-app-service.azurewebsites.net"
   }
 }
 
 inputs = {
-  common_resource_group_name           = dependency.common.outputs.common_resource_group_name
-  national_infrastructure_frontend_url = dependency.applications-service.outputs.national_infrastructure_frontend_url
+  common_resource_group_name = dependency.common.outputs.common_resource_group_name
+  ni_frontend_url            = dependency.applications-service.outputs.ni_frontend_url
 }

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -1,0 +1,28 @@
+include {
+  path = "../../../config/terragrunt.hcl"
+}
+
+dependency "common" {
+  config_path                             = "../common"
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_merge_with_state           = true
+
+  mock_outputs = {
+    common_resource_group_name = "mock_resource_group_name"
+  }
+}
+
+dependency "applications-service" {
+  config_path                             = "../applications-service"
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_merge_with_state           = true
+
+  mock_outputs = {
+    national_infrastructure_frontend_url = "https://mock-app-service.azurewebsites.net"
+  }
+}
+
+inputs = {
+  common_resource_group_name           = dependency.common.outputs.common_resource_group_name
+  national_infrastructure_frontend_url = dependency.applications-service.outputs.national_infrastructure_frontend_url
+}

--- a/app/stacks/front-door/variables.tf
+++ b/app/stacks/front-door/variables.tf
@@ -1,3 +1,8 @@
+variable "app_service_urls" {
+  description = "A map of frontend app service URLs"
+  type        = map(string)
+}
+
 variable "common_resource_group_name" {
   description = "The common infrastructure resource group name"
   type        = string
@@ -17,11 +22,6 @@ variable "instance" {
   description = "The environment instance for use if multiple environments are deployed to a subscription"
   type        = string
   default     = "001"
-}
-
-variable "ni_frontend_url" {
-  description = "The URL of the applications service national infrastructure frontend app service"
-  type        = string
 }
 
 variable "region" {

--- a/app/stacks/front-door/variables.tf
+++ b/app/stacks/front-door/variables.tf
@@ -19,7 +19,7 @@ variable "instance" {
   default     = "001"
 }
 
-variable "national_infrastructure_frontend_url" {
+variable "ni_frontend_url" {
   description = "The URL of the applications service national infrastructure frontend app service"
   type        = string
 }

--- a/app/stacks/front-door/variables.tf
+++ b/app/stacks/front-door/variables.tf
@@ -1,0 +1,31 @@
+variable "common_resource_group_name" {
+  description = "The common infrastructure resource group name"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "The common resource tags for the project"
+  type        = map(string)
+}
+
+variable "environment" {
+  description = "The environment resources are deployed to e.g. 'dev'"
+  type        = string
+}
+
+variable "instance" {
+  description = "The environment instance for use if multiple environments are deployed to a subscription"
+  type        = string
+  default     = "001"
+}
+
+variable "national_infrastructure_frontend_url" {
+  description = "The URL of the applications service national infrastructure frontend app service"
+  type        = string
+}
+
+variable "region" {
+  description = "The region resources are deployed to in slug format e.g. 'uk-south'"
+  type        = string
+  default     = "uk-south"
+}

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -19,6 +19,7 @@ parameters:
       - common
       - appeals-service
       - applications-service
+      - front-door
 
 trigger: none
 


### PR DESCRIPTION
- Deploys a Front Door instance per environment.
- Includes a default frontend `*.azurefd.net/*` with routing rule to the National Infrastructure frontend app service.
- Adds a dynamic access restriction to frontend web apps to ensure only connections from Front Door are accepted.
- _N.B._ Custom domain frontends and routing rules to be added in a later PR (semi-dependent on SSL certificates).
- _N.B._ Front Door may move to the tooling subscription to act as a shared resource if desirable. 