### PR TITLE
Add key vault policy for app services and fix secret references

### DIFF
--- a/app/modules/node-app-service/README.md
+++ b/app/modules/node-app-service/README.md
@@ -23,7 +23,9 @@ No modules.
 |------|------|
 | [azurerm_app_service.app_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service) | resource |
 | [azurerm_app_service_virtual_network_swift_connection.vnet_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_virtual_network_swift_connection) | resource |
+| [azurerm_key_vault_access_policy.read_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_private_endpoint.private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
@@ -41,6 +43,7 @@ No modules.
 | <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | `null` | no |
 | <a name="input_inbound_vnet_connectivity"></a> [inbound\_vnet\_connectivity](#input\_inbound\_vnet\_connectivity) | Indicates whether inbound connectivity (Private Endpoint) is required | `bool` | `false` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | `null` | no |
+| <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The name of the app service location | `string` | n/a | yes |
 | <a name="input_outbound_vnet_connectivity"></a> [outbound\_vnet\_connectivity](#input\_outbound\_vnet\_connectivity) | Indicates whether outbound connectivity (VNET Integration) is required | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |

--- a/app/modules/node-app-service/data.tf
+++ b/app/modules/node-app-service/data.tf
@@ -1,0 +1,1 @@
+data "azurerm_client_config" "current" {}

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -76,3 +76,13 @@ resource "azurerm_app_service_virtual_network_swift_connection" "vnet_connection
   app_service_id = azurerm_app_service.app_service.id
   subnet_id      = var.integration_subnet_id
 }
+
+resource "azurerm_key_vault_access_policy" "read_secrets" {
+  count = var.key_vault_id != null ? 1 : 0
+
+  key_vault_id = var.key_vault_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_app_service.app_service.identity.0.principal_id
+
+  secret_permissions = ["Get"]
+}

--- a/app/modules/node-app-service/variables.tf
+++ b/app/modules/node-app-service/variables.tf
@@ -71,6 +71,12 @@ variable "location" {
   type        = string
 }
 
+variable "key_vault_id" {
+  description = "The ID of the key vault so the App Service can pull secret values"
+  type        = string
+  default     = null
+}
+
 variable "outbound_vnet_connectivity" {
   default     = false
   description = "Indicates whether outbound connectivity (VNET Integration) is required"

--- a/app/stacks/applications-service/README.md
+++ b/app/stacks/applications-service/README.md
@@ -53,6 +53,7 @@ No requirements.
 | <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
+| <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
 | <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_national_infrastructure_gateway_ip"></a> [national\_infrastructure\_gateway\_ip](#input\_national\_infrastructure\_gateway\_ip) | The public IP address of the National Infrastructure gateway endpoint | `string` | n/a | yes |

--- a/app/stacks/applications-service/app-service.tf
+++ b/app/stacks/applications-service/app-service.tf
@@ -41,6 +41,7 @@ module "national_infrastructure_service" {
   container_registry_server_password = data.azurerm_container_registry.acr.admin_password
   container_registry_server_username = data.azurerm_container_registry.acr.admin_username
   endpoint_subnet_id                 = azurerm_subnet.applicatons_service_ingress.id
+  key_vault_id                       = var.key_vault_id
   inbound_vnet_connectivity          = true
   integration_subnet_id              = var.integration_subnet_id
   location                           = azurerm_resource_group.applications_service_stack.location

--- a/app/stacks/applications-service/terragrunt.hcl
+++ b/app/stacks/applications-service/terragrunt.hcl
@@ -22,6 +22,7 @@ dependency "common" {
     }
     common_vnet_gateway_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Network/virtualNetworkGateways/mock_id"
     common_vnet_name       = "mock_vnet_name"
+    key_vault_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.KeyVault/vaults/mockvault"
     key_vault_secret_refs = {
       applications-service-encryption-secret-key = "mock_secret"
       applications-service-mysql-database        = "mock_secret"
@@ -45,6 +46,7 @@ inputs = {
   common_vnet_cidr_blocks                     = dependency.common.outputs.common_vnet_cidr_blocks
   common_vnet_gateway_id                      = dependency.common.outputs.common_vnet_gateway_id
   common_vnet_name                            = dependency.common.outputs.common_vnet_name
+  key_vault_id                                = dependency.common.outputs.key_vault_id
   key_vault_secret_refs                       = dependency.common.outputs.key_vault_secret_refs
   integration_subnet_id                       = dependency.common.outputs.integration_subnet_id
 }

--- a/app/stacks/applications-service/variables.tf
+++ b/app/stacks/applications-service/variables.tf
@@ -93,6 +93,11 @@ variable "logger_level" {
   default     = "info"
 }
 
+variable "key_vault_id" {
+  description = "The ID of the key vault so the App Service can pull secret values"
+  type        = string
+}
+
 variable "key_vault_secret_refs" {
   description = "Map of secret references from the Key Vault"
   type        = map(string)

--- a/app/stacks/common/README.md
+++ b/app/stacks/common/README.md
@@ -69,5 +69,6 @@ No requirements.
 | <a name="output_common_vnet_gateway_id"></a> [common\_vnet\_gateway\_id](#output\_common\_vnet\_gateway\_id) | The id of the common infrastructure virtual network gateway |
 | <a name="output_common_vnet_name"></a> [common\_vnet\_name](#output\_common\_vnet\_name) | The name of the common infrastructure virtual network |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
+| <a name="output_key_vault_id"></a> [key\_vault\_id](#output\_key\_vault\_id) | The ID of the key vault so App Services can pull secret values |
 | <a name="output_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#output\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/common/locals.tf
+++ b/app/stacks/common/locals.tf
@@ -20,6 +20,6 @@ locals {
   ]
 
   secret_refs = {
-    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.environment_key_vault.vault_uri}secrets/${name}"
+    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.environment_key_vault.vault_uri}secrets/${name}/)"
   }
 }

--- a/app/stacks/common/outputs.tf
+++ b/app/stacks/common/outputs.tf
@@ -46,6 +46,11 @@ output "integration_subnet_id" {
   value       = azurerm_subnet.integration_subnet.id
 }
 
+output "key_vault_id" {
+  description = "The ID of the key vault so App Services can pull secret values"
+  value       = azurerm_key_vault.environment_key_vault.id
+}
+
 output "key_vault_secret_refs" {
   description = "Map of secret references from the Key Vault"
   value       = local.secret_refs


### PR DESCRIPTION
- Added `azurerm_key_vault_access_policy` resource so App Services can access Key Vault
- Fixed secret references as they were missing closing bracket