### PR TITLE
Add custom domains for all environments

### DIFF
--- a/app/stacks/appeals-service/README.md
+++ b/app/stacks/appeals-service/README.md
@@ -80,5 +80,7 @@ No requirements.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_app_service_urls"></a> [app\_service\_urls](#output\_app\_service\_urls) | A map of frontend app service URLs |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/appeals-service/outputs.tf
+++ b/app/stacks/appeals-service/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_urls" {
+  description = "A map of frontend app service URLs"
+  value = {
+    appeals_service_frontend = module.appeal_service_frontend.default_site_hostname
+    # lpa_questionnaire_frontend =
+  }
+}

--- a/app/stacks/appeals-service/outputs.tf
+++ b/app/stacks/appeals-service/outputs.tf
@@ -2,6 +2,5 @@ output "app_service_urls" {
   description = "A map of frontend app service URLs"
   value = {
     appeals_service_frontend = module.appeal_service_frontend.default_site_hostname
-    # lpa_questionnaire_frontend =
   }
 }

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -1,7 +1,4 @@
 resource "azurerm_frontdoor" "common" {
-  #TODO: Add frontend endpoints for custom domains:
-  # - Applications: www.national-infrastructure.planninginspectorate.gov.uk
-  # - Appeals:      appeal-planning-decision.planninginspectorate.gov.uk
   #checkov:skip=CKV_AZURE_121: WAF to be implemented later
   name                                         = "pins-fd-${local.service_name}-${local.resource_suffix}"
   resource_group_name                          = var.common_resource_group_name

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -50,9 +50,9 @@ resource "azurerm_frontdoor" "common" {
 
   routing_rule {
     enabled            = true
-    name               = "ForwardHttps"
+    name               = "Default"
     accepted_protocols = ["Http", "Https"]
-    patterns_to_match  = ["/"]
+    patterns_to_match  = ["/*"]
     frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
     forwarding_configuration {

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -28,44 +28,44 @@ resource "azurerm_frontdoor" "common" {
   # Default Frontend Endpoint
   #========================================================================
 
-  # frontend_endpoint {
-  #   name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
-  #   host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
+  frontend_endpoint {
+    name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
+    host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
 
-  #   # web_application_firewall_policy_link_id
-  # }
+    # web_application_firewall_policy_link_id
+  }
 
-  # backend_pool {
-  #   name                = "Default"
-  #   load_balancing_name = "Default"
-  #   health_probe_name   = "Http"
+  backend_pool {
+    name                = "Default"
+    load_balancing_name = "Default"
+    health_probe_name   = "Http"
 
-  #   backend {
-  #     enabled     = true
-  #     address     = "www.gov.uk"
-  #     host_header = "www.gov.uk"
-  #     http_port   = 80
-  #     https_port  = 443
-  #     priority    = 5
-  #     weight      = 100
-  #   }
-  # }
+    backend {
+      enabled     = true
+      address     = "www.gov.uk"
+      host_header = "www.gov.uk"
+      http_port   = 80
+      https_port  = 443
+      priority    = 5
+      weight      = 100
+    }
+  }
 
-  # routing_rule {
-  #   enabled            = true
-  #   name               = "ForwardHttps"
-  #   accepted_protocols = ["Http", "Https"]
-  #   patterns_to_match  = ["/"]
-  #   frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
+  routing_rule {
+    enabled            = true
+    name               = "ForwardHttps"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/"]
+    frontend_endpoints = ["pins-fd-${local.service_name}-${local.resource_suffix}"]
 
-  #   forwarding_configuration {
-  #     backend_pool_name      = "Default"
-  #     cache_enabled          = false
-  #     cache_query_parameters = []
-  #     custom_forwarding_path = "/government/organisations/planning-inspectorate"
-  #     forwarding_protocol    = "MatchRequest"
-  #   }
-  # }
+    forwarding_configuration {
+      backend_pool_name      = "Default"
+      cache_enabled          = false
+      cache_query_parameters = []
+      custom_forwarding_path = "/government/organisations/planning-inspectorate"
+      forwarding_protocol    = "MatchRequest"
+    }
+  }
 
   #========================================================================
   # Dynamic Service Frontend Endpoints

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -10,11 +10,6 @@ locals {
       frontend_endpoint = var.appeals_service_public_url
       patterns_to_match = ["/*"]
     }
-    # lpa_questionnaire_frontend = {
-    #   name              = "LpaQuestionnaire"
-    #   frontend_endpoint = var.lpa_questionnaire_public_url
-    #   patterns_to_match = ["/*"]
-    # }
   }
   service_name    = "common"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,10 +1,5 @@
 locals {
   frontend_mappings = {
-    default = {
-      name              = "pins-fd-${local.service_name}-${local.resource_suffix}"
-      frontend_endpoint = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
-      patterns_to_match = ["/*"]
-    }
     national_infrastructure_frontend = {
       name              = "NationalInfrastructure"
       frontend_endpoint = var.applications_service_public_url

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -1,10 +1,25 @@
 locals {
   frontend_mappings = {
-    national_infrastructure_frontend = {
+    default = {
       name              = "pins-fd-${local.service_name}-${local.resource_suffix}"
       frontend_endpoint = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
       patterns_to_match = ["/*"]
     }
+    national_infrastructure_frontend = {
+      name              = "NationalInfrastructure"
+      frontend_endpoint = var.applications_service_public_url
+      patterns_to_match = ["/*"]
+    }
+    appeals_service_frontend = {
+      name              = "AppealsService"
+      frontend_endpoint = var.appeals_service_public_url
+      patterns_to_match = ["/*"]
+    }
+    # lpa_questionnaire_frontend = {
+    #   name              = "LpaQuestionnaire"
+    #   frontend_endpoint = var.lpa_questionnaire_public_url
+    #   patterns_to_match = ["/*"]
+    # }
   }
   service_name    = "front-door"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"

--- a/app/stacks/front-door/locals.tf
+++ b/app/stacks/front-door/locals.tf
@@ -16,7 +16,7 @@ locals {
     #   patterns_to_match = ["/*"]
     # }
   }
-  service_name    = "front-door"
+  service_name    = "common"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
   tags = merge(
     var.common_tags,

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -20,7 +20,6 @@ dependency "appeals_service" {
   mock_outputs = {
     app_service_urls = {
       appeals_service_frontend = "mock_url"
-      # lpa_questionnaire_frontend = "mock_url"
     }
   }
 }

--- a/app/stacks/front-door/terragrunt.hcl
+++ b/app/stacks/front-door/terragrunt.hcl
@@ -12,6 +12,19 @@ dependency "common" {
   }
 }
 
+dependency "appeals_service" {
+  config_path                             = "../appeals-service"
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_merge_with_state           = true
+
+  mock_outputs = {
+    app_service_urls = {
+      appeals_service_frontend = "mock_url"
+      # lpa_questionnaire_frontend = "mock_url"
+    }
+  }
+}
+
 dependency "applications_service" {
   config_path                             = "../applications-service"
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
@@ -25,6 +38,9 @@ dependency "applications_service" {
 }
 
 inputs = {
-  app_service_urls           = dependency.applications_service.outputs.app_service_urls
+  app_service_urls = merge(
+    dependency.applications_service.outputs.app_service_urls,
+    dependency.appeals_service.outputs.app_service_urls
+  )
   common_resource_group_name = dependency.common.outputs.common_resource_group_name
 }

--- a/app/stacks/front-door/variables.tf
+++ b/app/stacks/front-door/variables.tf
@@ -34,11 +34,6 @@ variable "instance" {
   default     = "001"
 }
 
-# variable "lpa_questionnaire_public_url" {
-#   description = "The public URL for the Appeals LPA Questionnaire frontend web app"
-#   type        = string
-# }
-
 variable "region" {
   description = "The region resources are deployed to in slug format e.g. 'uk-south'"
   type        = string

--- a/app/stacks/front-door/variables.tf
+++ b/app/stacks/front-door/variables.tf
@@ -3,6 +3,16 @@ variable "app_service_urls" {
   type        = map(string)
 }
 
+variable "appeals_service_public_url" {
+  description = "The public URL for the Appeals Service frontend web app"
+  type        = string
+}
+
+variable "applications_service_public_url" {
+  description = "The public URL for the Applications Service frontend web app"
+  type        = string
+}
+
 variable "common_resource_group_name" {
   description = "The common infrastructure resource group name"
   type        = string
@@ -23,6 +33,11 @@ variable "instance" {
   type        = string
   default     = "001"
 }
+
+# variable "lpa_questionnaire_public_url" {
+#   description = "The public URL for the Appeals LPA Questionnaire frontend web app"
+#   type        = string
+# }
 
 variable "region" {
   description = "The region resources are deployed to in slug format e.g. 'uk-south'"

--- a/config/variables/dev.hcl
+++ b/config/variables/dev.hcl
@@ -1,8 +1,11 @@
 locals {
-  api_timeout                                = 10000
-  environment                                = "dev"
-  common_vnet_address_space                  = "10.1.0.0/16"
-  google_analytics_id                        = "G-X21W2S2FN3"
+  api_timeout                     = 10000
+  appeals_service_public_url      = "appeals-service-dev.planninginspectorate.gov.uk"
+  applications_service_public_url = "applications-service-dev.planninginspectorate.gov.uk"
+  common_vnet_address_space       = "10.1.0.0/16"
+  environment                     = "dev"
+  google_analytics_id             = "G-X21W2S2FN3"
+  # lpa_questionnaire_public_url               = "lpa-questionnaire-dev.planninginspectorate.gov.uk"
   national_infrastructure_gateway_ip         = "51.104.42.155"
   national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
   srv_notify_base_url                        = "https://api.notifications.service.gov.uk/"

--- a/config/variables/dev.hcl
+++ b/config/variables/dev.hcl
@@ -1,11 +1,10 @@
 locals {
-  api_timeout                     = 10000
-  appeals_service_public_url      = "appeals-service-dev.planninginspectorate.gov.uk"
-  applications_service_public_url = "applications-service-dev.planninginspectorate.gov.uk"
-  common_vnet_address_space       = "10.1.0.0/16"
-  environment                     = "dev"
-  google_analytics_id             = "G-X21W2S2FN3"
-  # lpa_questionnaire_public_url               = "lpa-questionnaire-dev.planninginspectorate.gov.uk"
+  api_timeout                                = 10000
+  appeals_service_public_url                 = "appeals-service-dev.planninginspectorate.gov.uk"
+  applications_service_public_url            = "applications-service-dev.planninginspectorate.gov.uk"
+  common_vnet_address_space                  = "10.1.0.0/16"
+  environment                                = "dev"
+  google_analytics_id                        = "G-X21W2S2FN3"
   national_infrastructure_gateway_ip         = "51.104.42.155"
   national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
   srv_notify_base_url                        = "https://api.notifications.service.gov.uk/"

--- a/config/variables/prod.hcl
+++ b/config/variables/prod.hcl
@@ -1,12 +1,13 @@
 locals {
-  api_timeout                                = 10000
-  appeals_service_public_url                 = "appeal-planning-decision.planninginspectorate.gov.uk"
-  applications_service_public_url            = "www.national-infrastructure.planninginspectorate.gov.uk"
-  environment                                = "prod"
-  common_vnet_address_space                  = "10.3.0.0/16"
-  logger_level                               = "info"
-  node_environment                           = "production"
-  google_analytics_id                        = "tbc"
+  api_timeout                     = 10000
+  appeals_service_public_url      = "appeals-service-prod.planninginspectorate.gov.uk"      # "appeal-planning-decision.planninginspectorate.gov.uk"
+  applications_service_public_url = "applications-service-prod.planninginspectorate.gov.uk" # "www.national-infrastructure.planninginspectorate.gov.uk"
+  environment                     = "prod"
+  common_vnet_address_space       = "10.3.0.0/16"
+  logger_level                    = "info"
+  node_environment                = "production"
+  google_analytics_id             = "tbc"
+  # lpa_questionnaire_public_url               = "lpa-questionnaire-prod.planninginspectorate.gov.uk"
   national_infrastructure_gateway_ip         = "51.104.42.155"
   national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
   srv_notify_base_url                        = "https://api.notifications.service.gov.uk/"

--- a/config/variables/prod.hcl
+++ b/config/variables/prod.hcl
@@ -1,5 +1,7 @@
 locals {
   api_timeout                                = 10000
+  appeals_service_public_url                 = "appeal-planning-decision.planninginspectorate.gov.uk"
+  applications_service_public_url            = "www.national-infrastructure.planninginspectorate.gov.uk"
   environment                                = "prod"
   common_vnet_address_space                  = "10.3.0.0/16"
   logger_level                               = "info"

--- a/config/variables/prod.hcl
+++ b/config/variables/prod.hcl
@@ -1,13 +1,12 @@
 locals {
-  api_timeout                     = 10000
-  appeals_service_public_url      = "appeals-service-prod.planninginspectorate.gov.uk"      # "appeal-planning-decision.planninginspectorate.gov.uk"
-  applications_service_public_url = "applications-service-prod.planninginspectorate.gov.uk" # "www.national-infrastructure.planninginspectorate.gov.uk"
-  environment                     = "prod"
-  common_vnet_address_space       = "10.3.0.0/16"
-  logger_level                    = "info"
-  node_environment                = "production"
-  google_analytics_id             = "tbc"
-  # lpa_questionnaire_public_url               = "lpa-questionnaire-prod.planninginspectorate.gov.uk"
+  api_timeout                                = 10000
+  appeals_service_public_url                 = "appeals-service-prod.planninginspectorate.gov.uk"      # "appeal-planning-decision.planninginspectorate.gov.uk"
+  applications_service_public_url            = "applications-service-prod.planninginspectorate.gov.uk" # "www.national-infrastructure.planninginspectorate.gov.uk"
+  environment                                = "prod"
+  common_vnet_address_space                  = "10.3.0.0/16"
+  logger_level                               = "info"
+  node_environment                           = "production"
+  google_analytics_id                        = "tbc"
   national_infrastructure_gateway_ip         = "51.104.42.155"
   national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
   srv_notify_base_url                        = "https://api.notifications.service.gov.uk/"

--- a/config/variables/test.hcl
+++ b/config/variables/test.hcl
@@ -1,8 +1,11 @@
 locals {
-  api_timeout                                = 10000
-  environment                                = "test"
-  common_vnet_address_space                  = "10.2.0.0/16"
-  google_analytics_id                        = "G-X21W2S2FN3"
+  api_timeout                     = 10000
+  appeals_service_public_url      = "appeals-service-test.planninginspectorate.gov.uk"
+  applications_service_public_url = "applications-service-test.planninginspectorate.gov.uk"
+  environment                     = "test"
+  common_vnet_address_space       = "10.2.0.0/16"
+  google_analytics_id             = "G-X21W2S2FN3"
+  # lpa_questionnaire_public_url               = "lpa-questionnaire-test.planninginspectorate.gov.uk"
   national_infrastructure_gateway_ip         = "51.104.42.155"
   national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
   srv_notify_base_url                        = "https://api.notifications.service.gov.uk/"

--- a/config/variables/test.hcl
+++ b/config/variables/test.hcl
@@ -1,11 +1,10 @@
 locals {
-  api_timeout                     = 10000
-  appeals_service_public_url      = "appeals-service-test.planninginspectorate.gov.uk"
-  applications_service_public_url = "applications-service-test.planninginspectorate.gov.uk"
-  environment                     = "test"
-  common_vnet_address_space       = "10.2.0.0/16"
-  google_analytics_id             = "G-X21W2S2FN3"
-  # lpa_questionnaire_public_url               = "lpa-questionnaire-test.planninginspectorate.gov.uk"
+  api_timeout                                = 10000
+  appeals_service_public_url                 = "appeals-service-test.planninginspectorate.gov.uk"
+  applications_service_public_url            = "applications-service-test.planninginspectorate.gov.uk"
+  environment                                = "test"
+  common_vnet_address_space                  = "10.2.0.0/16"
+  google_analytics_id                        = "G-X21W2S2FN3"
   national_infrastructure_gateway_ip         = "51.104.42.155"
   national_infrastructure_vnet_address_space = ["10.222.0.0/26"]
   srv_notify_base_url                        = "https://api.notifications.service.gov.uk/"


### PR DESCRIPTION
- Added custom domain names for Dev, Pre-Prod, and Production.
- Changed service name for the Front Door stack to common.
- Deployed to test and confirmed working subsequent to public DNS records being registered.