### PR TITLE
Add WAF to Front Door

### DIFF
--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -1,5 +1,5 @@
 resource "azurerm_frontdoor" "common" {
-  #checkov:skip=CKV_AZURE_121: WAF to be implemented later
+  #checkov:skip=CKV_AZURE_121: WAF implemented but Checkov still fails
   name                                         = "pins-fd-${local.service_name}-${local.resource_suffix}"
   resource_group_name                          = var.common_resource_group_name
   enforce_backend_pools_certificate_name_check = false

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -1,5 +1,5 @@
 resource "azurerm_frontdoor" "common" {
-  #checkov:skip=CKV_AZURE_121: WAF implemented but Checkov still fails
+  #checkov:skip=CKV_AZURE_121: WAF implemented but Checkov still fails: https://github.com/bridgecrewio/checkov/issues/2617
   name                                         = "pins-fd-${local.service_name}-${local.resource_suffix}"
   resource_group_name                          = var.common_resource_group_name
   enforce_backend_pools_certificate_name_check = false

--- a/app/stacks/front-door/front-door.tf
+++ b/app/stacks/front-door/front-door.tf
@@ -26,10 +26,9 @@ resource "azurerm_frontdoor" "common" {
   #========================================================================
 
   frontend_endpoint {
-    name      = "pins-fd-${local.service_name}-${local.resource_suffix}"
-    host_name = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
-
-    # web_application_firewall_policy_link_id
+    name                                    = "pins-fd-${local.service_name}-${local.resource_suffix}"
+    host_name                               = "pins-fd-${local.service_name}-${local.resource_suffix}.azurefd.net"
+    web_application_firewall_policy_link_id = azurerm_frontdoor_firewall_policy.default.id
   }
 
   backend_pool {
@@ -73,8 +72,9 @@ resource "azurerm_frontdoor" "common" {
     iterator = mapping
 
     content {
-      name      = mapping.value["name"]
-      host_name = mapping.value["frontend_endpoint"]
+      name                                    = mapping.value["name"]
+      host_name                               = mapping.value["frontend_endpoint"]
+      web_application_firewall_policy_link_id = azurerm_frontdoor_firewall_policy.default.id
     }
   }
 

--- a/app/stacks/front-door/waf-policy.tf
+++ b/app/stacks/front-door/waf-policy.tf
@@ -1,5 +1,5 @@
 resource "azurerm_frontdoor_firewall_policy" "default" {
-  name                = "pins-waf-${local.service_name}-${local.resource_suffix}"
+  name                = "DefaultRuleSet"
   resource_group_name = var.common_resource_group_name
   enabled             = true
   mode                = "Prevention"

--- a/app/stacks/front-door/waf-policy.tf
+++ b/app/stacks/front-door/waf-policy.tf
@@ -1,0 +1,12 @@
+resource "azurerm_frontdoor_firewall_policy" "default" {
+  name                = "pins-waf-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = var.common_resource_group_name
+  enabled             = true
+  mode                = "Prevention"
+  tags                = var.common_tags
+
+  managed_rule {
+    type    = "DefaultRuleSet"
+    version = "1.0"
+  }
+}

--- a/app/stacks/front-door/waf-policy.tf
+++ b/app/stacks/front-door/waf-policy.tf
@@ -1,5 +1,5 @@
 resource "azurerm_frontdoor_firewall_policy" "default" {
-  name                = "DefaultRuleSet"
+  name                = replace("pinswaf${local.service_name}${local.resource_suffix}", "-", "")
   resource_group_name = var.common_resource_group_name
   enabled             = true
   mode                = "Prevention"


### PR DESCRIPTION
- Adds a basic Web Application Firewall policy to all Front Door frontends.
- Includes all [Default Rule Set](https://docs.microsoft.com/en-us/azure/web-application-firewall/afds/waf-front-door-drs?tabs=drs20#default-rule-sets) managed policy settings. Does not include [Bot Rules (Preview)](https://docs.microsoft.com/en-us/azure/web-application-firewall/afds/waf-front-door-drs?tabs=drs20#bot-rules).