### PR TITLE
Change node environment variable for Dev

### DIFF
--- a/config/variables/dev.hcl
+++ b/config/variables/dev.hcl
@@ -4,7 +4,7 @@ locals {
   applications_service_public_url = "applications-service-dev.planninginspectorate.gov.uk"
   environment                     = "dev"
   logger_level                    = "info"
-  node_environment                = "production"
+  node_environment                = "development"
   primary_vnet_address_space      = ["10.1.0.0/16"]
   secondary_vnet_address_space    = ["10.11.0.0/16"]
   srv_notify_base_url             = "https://api.notifications.service.gov.uk/"


### PR DESCRIPTION
- Changes the node environment variable for Dev to `development` to prevent the Applications service API App Service database connection from using localhost. 