### PR TITLE
Remove Front Door dependency on Appeals service stack

### DIFF
--- a/app/stacks/global/front-door/terragrunt.hcl
+++ b/app/stacks/global/front-door/terragrunt.hcl
@@ -52,8 +52,9 @@ dependency "applications_service_ukw" {
 
 inputs = {
   app_service_urls = merge(
-    dependency.appeals_service_uks.outputs.app_service_urls,
-    dependency.appeals_service_ukw.outputs.app_service_urls,
+    # dependency.appeals_service_uks.outputs.app_service_urls,
+    # dependency.appeals_service_ukw.outputs.app_service_urls,
+
     dependency.applications_service_uks.outputs.app_service_urls,
     dependency.applications_service_ukw.outputs.app_service_urls
   )

--- a/app/stacks/global/front-door/terragrunt.hcl
+++ b/app/stacks/global/front-door/terragrunt.hcl
@@ -2,29 +2,29 @@ include {
   path = "../../../../config/terragrunt.hcl"
 }
 
-dependency "appeals_service_uks" {
-  config_path                             = "../../uk-south/appeals-service"
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  mock_outputs_merge_with_state           = true
+# dependency "appeals_service_uks" {
+#   config_path                             = "../../uk-south/appeals-service"
+#   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+#   mock_outputs_merge_with_state           = true
 
-  mock_outputs = {
-    app_service_urls = {
-      appeals_frontend_uks = "mock-wfe-url"
-    }
-  }
-}
+#   mock_outputs = {
+#     app_service_urls = {
+#       appeals_frontend_uks = "mock-wfe-url"
+#     }
+#   }
+# }
 
-dependency "appeals_service_ukw" {
-  config_path                             = "../../uk-west/appeals-service"
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  mock_outputs_merge_with_state           = true
+# dependency "appeals_service_ukw" {
+#   config_path                             = "../../uk-west/appeals-service"
+#   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+#   mock_outputs_merge_with_state           = true
 
-  mock_outputs = {
-    app_service_urls = {
-      appeals_frontend_ukw = "mock-wfe-url"
-    }
-  }
-}
+#   mock_outputs = {
+#     app_service_urls = {
+#       appeals_frontend_ukw = "mock-wfe-url"
+#     }
+#   }
+# }
 
 dependency "applications_service_uks" {
   config_path                             = "../../uk-south/applications-service"


### PR DESCRIPTION
- Temporary solution to work around Cosmos DB outages in UK South affecting the deployment of the Appeals service stack. Allows Front Door to be deployed just for the Applications service to facilitate environment deployments to Test and Prod.