### PR TITLE
Add remote gateway IPs and address spaces for Applications connectivity

### DIFF
--- a/config/variables/stacks/applications-service/prod.hcl
+++ b/config/variables/stacks/applications-service/prod.hcl
@@ -1,7 +1,7 @@
 locals {
   google_analytics_id                                             = "G-DQ9S57CJDP"
-  national_infrastructure_gateway_ip                              = "51.104.42.155"
-  national_infrastructure_vnet_address_space                      = ["10.222.0.0/26"]
+  national_infrastructure_gateway_ip                              = "51.140.221.209"
+  national_infrastructure_vnet_address_space                      = ["10.224.161.0/24", "192.168.0.0/20"]
   srv_notify_ip_registration_confirmation_email_to_ip_template_id = "442ee953-7bd2-4b44-aa38-9dc8a3e42ab4"
   srv_notify_magic_link_email_template_id                         = "0f4635cf-eed0-487a-83ff-a325800f9c9c"
   srv_notify_service_id                                           = "2f25f917-c24f-44a6-9d0c-aebac7c98081"

--- a/config/variables/stacks/applications-service/test.hcl
+++ b/config/variables/stacks/applications-service/test.hcl
@@ -1,7 +1,7 @@
 locals {
   google_analytics_id                                             = "G-566E329TBN"
-  national_infrastructure_gateway_ip                              = "51.104.42.155"
-  national_infrastructure_vnet_address_space                      = ["10.222.0.0/26"]
+  national_infrastructure_gateway_ip                              = "51.141.40.109"
+  national_infrastructure_vnet_address_space                      = ["10.0.0.0/20"]
   srv_notify_ip_registration_confirmation_email_to_ip_template_id = "830c9c01-1f81-4198-be72-11ab173c128a"
   srv_notify_magic_link_email_template_id                         = "4ca6b93a-4c45-4abe-a8ea-69ba13c80915"
   srv_notify_service_id                                           = "9b89eb93-3071-432c-9c6b-4e07dbda9071"


### PR DESCRIPTION
- Adds the remote virtual network gateway public IP addresses and address space.
- Allows the Applications service for Test and Prod environments to establish connectivity to the respective NI SQL database.