### PR TITLE
Add additional app settings for frontend, documents api, and pdf api

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -40,10 +40,13 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_service_private_dns_zone_id"></a> [app\_service\_private\_dns\_zone\_id](#input\_app\_service\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
+| <a name="input_appeal_documents_primary_blob_connection_string"></a> [appeal\_documents\_primary\_blob\_connection\_string](#input\_appeal\_documents\_primary\_blob\_connection\_string) | The Appeal Documents Storage Account blob connection string associated with the primary location | `string` | n/a | yes |
+| <a name="input_appeal_documents_storage_container_name"></a> [appeal\_documents\_storage\_container\_name](#input\_appeal\_documents\_storage\_container\_name) | The name of the Storage Container for Appeal Documents | `string` | n/a | yes |
 | <a name="input_appeals_service_public_url"></a> [appeals\_service\_public\_url](#input\_appeals\_service\_public\_url) | The public URL for the Appeals Service frontend web app | `string` | n/a | yes |
 | <a name="input_container_registry_login_server"></a> [container\_registry\_login\_server](#input\_container\_registry\_login\_server) | The URL used to connect to the Azure Container Registry | `string` | n/a | yes |
 | <a name="input_container_registry_password"></a> [container\_registry\_password](#input\_container\_registry\_password) | The password used to connect to the Azure Container Registry | `string` | n/a | yes |
@@ -52,6 +55,8 @@ No requirements.
 | <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
 | <a name="input_function_apps_storage_account"></a> [function\_apps\_storage\_account](#input\_function\_apps\_storage\_account) | The name of the storage account used by the Function Apps | `string` | n/a | yes |
 | <a name="input_function_apps_storage_account_primary_access_key"></a> [function\_apps\_storage\_account\_primary\_access\_key](#input\_function\_apps\_storage\_account\_primary\_access\_key) | The primary access key of the storage account used by the Function Apps | `string` | n/a | yes |
+| <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
+| <a name="input_google_tag_manager_id"></a> [google\_tag\_manager\_id](#input\_google\_tag\_manager\_id) | The id used to connect the frontend app to Google Tag Manager | `string` | n/a | yes |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
 | <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -13,7 +13,30 @@ locals {
       outbound_vnet_connectivity = true
 
       app_settings = {
-
+        APPEALS_SERVICE_API_TIMEOUT                = var.api_timeout
+        APPEALS_SERVICE_API_URL                    = "https://pins-app-${var.service_name}-appeals-api-${var.resource_suffix}.azurewebsites.net"
+        DOCS_API_PATH                              = "/opt/app/api"
+        DOCUMENTS_SERVICE_API_TIMEOUT              = var.api_timeout
+        DOCUMENTS_SERVICE_API_URL                  = "https://pins-app-${var.service_name}-documents-api-${var.resource_suffix}.azurewebsites.net/"
+        FEATURE_FLAG_GOOGLE_TAG_MANAGER            = true
+        FEATURE_FLAG_NEW_APPEAL_JOURNEY            = true
+        FILE_UPLOAD_DEBUG                          = true
+        FILE_UPLOAD_MAX_FILE_SIZE_BYTES            = "15000000"
+        FILE_UPLOAD_TMP_PATH                       = "/tmp"
+        FILE_UPLOAD_USE_TEMP_FILES                 = true
+        GOOGLE_ANALYTICS_ID                        = var.google_analytics_id
+        GOOGLE_TAG_MANAGER_ID                      = var.google_tag_manager_id
+        HORIZON_HAS_PUBLISHER_ATTEMPT_RECONNECTION = true
+        HOST_URL                                   = "https://${var.appeals_service_public_url}"
+        MICROSOFT_PROVIDER_AUTHENTICATION_SECRET   = var.key_vault_secret_refs["microsoft_provider_authentication_secret"]
+        PDF_SERVICE_API_URL                        = "https://pins-app-${var.service_name}-pdf-api-${var.resource_suffix}.azurewebsites.net"
+        PORT                                       = "3000"
+        SESSION_KEY                                = "some_key"
+        SESSION_MONGODB_COLLECTION                 = "sessions"
+        SESSION_MONGODB_DB_NAME                    = "forms-web-app"
+        SESSION_MONGODB_URL                        = var.cosmosdb_connection_string
+        SUBDOMAIN_OFFSET                           = "3"
+        USE_SECURE_SESSION_COOKIES                 = false
       }
     }
     #====================================
@@ -34,7 +57,7 @@ locals {
         APP_APPEALS_BASE_URL                                                        = "https://${var.appeals_service_public_url}"
         DOCS_API_PATH                                                               = "/opt/app/api"
         DOCUMENTS_SERVICE_API_TIMEOUT                                               = "10000"
-        DOCUMENTS_SERVICE_API_URL                                                   = "https://pins-app-${var.service_name}-documents-api-${var.resource_suffix}.azurewebsites.net/"
+        DOCUMENTS_SERVICE_API_URL                                                   = "https://pins-app-${var.service_name}-documents-api-${var.resource_suffix}.azurewebsites.net"
         FEATURE_FLAG_NEW_APPEAL_JOURNEY                                             = true
         HORIZON_HAS_PUBLISHER_ATTEMPT_RECONNECTION                                  = true
         HORIZON_HAS_PUBLISHER_HOST                                                  = "${azurerm_servicebus_namespace.horizon.name}.servicebus.windows.net"
@@ -76,24 +99,20 @@ locals {
       outbound_vnet_connectivity      = true
 
       app_settings = {
-        BLOB_STORAGE_CONNECTION_STRING      = ""
-        DOCS_API_PATH                       = "/opt/app/api"
-        FILE_MAX_SIZE_IN_BYTES              = "15000000"
-        FILE_UPLOAD_PATH                    = "/tmp/upload"
-        LOGGER_LEVEL                        = "debug"
-        MONGODB_AUTO_INDEX                  = "true"
-        MONGODB_DB_NAME                     = ""
-        MONGODB_URL                         = var.cosmosdb_connection_string
-        NODE_ENV                            = "production"
-        SERVER_PORT                         = "4000",
-        SERVER_SHOW_ERRORS                  = "true"
-        STORAGE_CONTAINER_NAME              = "uploads"
-        STORAGE_UPLOAD_MAX_ATTEMPTS         = "3"
-        STORAGE_UPLOAD_QUERY_LIMIT          = "5"
-        WEBSITE_HTTPLOGGING_RETENTION_DAYS  = "28"
-        WEBSITES_CONTAINER_START_TIME_LIMIT = "50000"
-        WEBSITES_ENABLE_APP_SERVICE_STORAGE = "false"
-        WEBSITES_PORT                       = "4000"
+        BLOB_STORAGE_CONNECTION_STRING = var.appeal_documents_primary_blob_connection_string
+        DOCS_API_PATH                  = "/opt/app/api"
+        FILE_MAX_SIZE_IN_BYTES         = "15000000"
+        FILE_UPLOAD_PATH               = "/tmp/upload"
+        LOGGER_LEVEL                   = var.logger_level
+        MONGODB_AUTO_INDEX             = true
+        MONGODB_DB_NAME                = "documents-service-api"
+        MONGODB_URL                    = var.cosmosdb_connection_string
+        NODE_ENV                       = var.node_environment
+        SERVER_PORT                    = "4000",
+        SERVER_SHOW_ERRORS             = true
+        STORAGE_CONTAINER_NAME         = var.appeal_documents_storage_container_name
+        STORAGE_UPLOAD_MAX_ATTEMPTS    = "3"
+        STORAGE_UPLOAD_QUERY_LIMIT     = "5"
       }
     }
 
@@ -107,7 +126,13 @@ locals {
       outbound_vnet_connectivity      = false
 
       app_settings = {
-
+        DOCS_API_PATH                           = "/opt/app/api"
+        GOTENBERG_URL                           = "http://gotenberg:4000"
+        LOGGER_LEVEL                            = var.logger_level
+        NODE_ENV                                = var.node_environment
+        SERVER_PORT                             = "3000"
+        SERVER_SHOW_ERRORS                      = true
+        SERVER_TERMINATION_GRACE_PERIOD_SECONDS = "0"
       }
     }
 

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -28,7 +28,7 @@ locals {
         GOOGLE_TAG_MANAGER_ID                      = var.google_tag_manager_id
         HORIZON_HAS_PUBLISHER_ATTEMPT_RECONNECTION = true
         HOST_URL                                   = "https://${var.appeals_service_public_url}"
-        MICROSOFT_PROVIDER_AUTHENTICATION_SECRET   = var.key_vault_secret_refs["microsoft_provider_authentication_secret"]
+        MICROSOFT_PROVIDER_AUTHENTICATION_SECRET   = var.key_vault_secret_refs["microsoft-provider-authentication-secret"]
         PDF_SERVICE_API_URL                        = "https://pins-app-${var.service_name}-pdf-api-${var.resource_suffix}.azurewebsites.net"
         PORT                                       = "3000"
         SESSION_KEY                                = "some_key"

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -9,7 +9,7 @@ locals {
       inbound_vnet_connectivity  = false
       integration_subnet_id      = var.integration_subnet_id
       image_name                 = "appeal-planning-decisions/forms-web-app"
-      key_vault_access           = false
+      key_vault_access           = true
       outbound_vnet_connectivity = true
 
       app_settings = {

--- a/app/components/appeals-app-services/variables.tf
+++ b/app/components/appeals-app-services/variables.tf
@@ -1,3 +1,8 @@
+variable "api_timeout" {
+  description = "The timeout in milliseconds for API calls in the frontend apps"
+  type        = string
+}
+
 variable "app_insights_connection_string" {
   description = "The connection string to connect to an Application Insights resource"
   sensitive   = true
@@ -17,6 +22,16 @@ variable "app_service_plan_id" {
 
 variable "app_service_private_dns_zone_id" {
   description = "The id of the private DNS zone for App services"
+  type        = string
+}
+
+variable "appeal_documents_primary_blob_connection_string" {
+  description = "The Appeal Documents Storage Account blob connection string associated with the primary location"
+  type        = string
+}
+
+variable "appeal_documents_storage_container_name" {
+  description = "The name of the Storage Container for Appeal Documents"
   type        = string
 }
 
@@ -65,6 +80,16 @@ variable "function_apps_storage_account_primary_access_key" {
   type        = string
 }
 
+variable "google_analytics_id" {
+  description = "The id used to connect the frontend app to Google Analytics"
+  type        = string
+}
+
+variable "google_tag_manager_id" {
+  description = "The id used to connect the frontend app to Google Tag Manager"
+  type        = string
+}
+
 variable "integration_subnet_id" {
   description = "The id of the vnet integration subnet the app service is linked to for egress traffic"
   type        = string
@@ -80,6 +105,11 @@ variable "key_vault_secret_refs" {
   type        = map(string)
 }
 
+variable "location" {
+  description = "The location the App Services are deployed to in slug format e.g. 'uk-south'"
+  type        = string
+}
+
 variable "logger_level" {
   description = "The level of logging enabled for applications in the environment e.g. info"
   type        = string
@@ -90,11 +120,6 @@ variable "node_environment" {
   description = "The node environment to be used for applications in this environment e.g. development"
   type        = string
   default     = "development"
-}
-
-variable "location" {
-  description = "The location the App Services are deployed to in slug format e.g. 'uk-south'"
-  type        = string
 }
 
 variable "resource_group_id" {

--- a/app/components/appeals-app-services/variables.tf
+++ b/app/components/appeals-app-services/variables.tf
@@ -27,6 +27,7 @@ variable "app_service_private_dns_zone_id" {
 
 variable "appeal_documents_primary_blob_connection_string" {
   description = "The Appeal Documents Storage Account blob connection string associated with the primary location"
+  sensitive   = true
   type        = string
 }
 

--- a/app/components/networking/README.md
+++ b/app/components/networking/README.md
@@ -41,6 +41,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_base_cidr_block"></a> [base\_cidr\_block](#input\_base\_cidr\_block) | The CIDR address space for the virtual network | `string` | n/a | yes |
+| <a name="input_cosmosdb_enable_public_access"></a> [cosmosdb\_enable\_public\_access](#input\_cosmosdb\_enable\_public\_access) | A flag to indicate if the database can be accessed over the internet | `string` | `false` | no |
 | <a name="input_deploy_national_infrastructure_vnet_gateway"></a> [deploy\_national\_infrastructure\_vnet\_gateway](#input\_deploy\_national\_infrastructure\_vnet\_gateway) | A flag to determine if the VNet gateway to the National Infrastructure subscription should be deployed | `bool` | n/a | yes |
 | <a name="input_env_network_region_short"></a> [env\_network\_region\_short](#input\_env\_network\_region\_short) | The location resources are deployed to in short format e.g. 'uks' | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |

--- a/app/components/networking/network.tf
+++ b/app/components/networking/network.tf
@@ -16,6 +16,8 @@ resource "azurerm_subnet" "vnet_gateway_subnet" {
 }
 
 resource "azurerm_subnet" "cosmosdb" {
+  count = var.cosmosdb_enable_public_access ? 0 : 1
+
   name                                           = "pins-snet-${var.service_name}-cosmosdb-${var.resource_suffix}"
   resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.common_infrastructure.name
@@ -24,6 +26,8 @@ resource "azurerm_subnet" "cosmosdb" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "cosmosdb_vnet_link" {
+  count = var.cosmosdb_enable_public_access ? 0 : 1
+
   name                  = "pins-vnetlink-${var.service_name}-cosmosdb-${var.resource_suffix}"
   resource_group_name   = var.tooling_network_rg
   private_dns_zone_name = "privatelink.mongo.cosmos.azure.com"

--- a/app/components/networking/outputs.tf
+++ b/app/components/networking/outputs.tf
@@ -1,6 +1,6 @@
 output "cosmosdb_subnet_id" {
   description = "The id of the Cosmos DB endpoint subnet"
-  value       = azurerm_subnet.cosmosdb.id
+  value       = length(azurerm_subnet.cosmosdb) > 0 ? azurerm_subnet.cosmosdb[0].id : null
 }
 
 output "integration_subnet_id" {

--- a/app/components/networking/variables.tf
+++ b/app/components/networking/variables.tf
@@ -3,6 +3,12 @@ variable "base_cidr_block" {
   type        = string
 }
 
+variable "cosmosdb_enable_public_access" {
+  description = "A flag to indicate if the database can be accessed over the internet"
+  type        = string
+  default     = false
+}
+
 variable "deploy_national_infrastructure_vnet_gateway" {
   description = "A flag to determine if the VNet gateway to the National Infrastructure subscription should be deployed"
   type        = bool

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -36,9 +36,12 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
+| <a name="input_appeal_documents_primary_blob_connection_string"></a> [appeal\_documents\_primary\_blob\_connection\_string](#input\_appeal\_documents\_primary\_blob\_connection\_string) | The Appeal Documents Storage Account blob connection string associated with the primary location | `string` | n/a | yes |
+| <a name="input_appeal_documents_storage_container_name"></a> [appeal\_documents\_storage\_container\_name](#input\_appeal\_documents\_storage\_container\_name) | The name of the Storage Container for Appeal Documents | `string` | n/a | yes |
 | <a name="input_appeals_service_public_url"></a> [appeals\_service\_public\_url](#input\_appeals\_service\_public\_url) | The public URL for the Appeals Service frontend web app | `string` | n/a | yes |
 | <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
@@ -52,6 +55,8 @@ No requirements.
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_function_apps_storage_account"></a> [function\_apps\_storage\_account](#input\_function\_apps\_storage\_account) | The name of the storage account used by the Function Apps | `string` | n/a | yes |
 | <a name="input_function_apps_storage_account_primary_access_key"></a> [function\_apps\_storage\_account\_primary\_access\_key](#input\_function\_apps\_storage\_account\_primary\_access\_key) | The primary access key of the storage account used by the Function Apps | `string` | n/a | yes |
+| <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
+| <a name="input_google_tag_manager_id"></a> [google\_tag\_manager\_id](#input\_google\_tag\_manager\_id) | The id used to connect the frontend app to Google Tag Manager | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_is_dr_deployment"></a> [is\_dr\_deployment](#input\_is\_dr\_deployment) | A flag to indicate whether or not the infrastructure deployment is for a disaster recovery scenario | `bool` | `false` | no |

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -50,6 +50,7 @@ No requirements.
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_cosmosdb_connection_string"></a> [cosmosdb\_connection\_string](#input\_cosmosdb\_connection\_string) | The connection string used to connect to CosmosDB | `string` | n/a | yes |
+| <a name="input_cosmosdb_enable_public_access"></a> [cosmosdb\_enable\_public\_access](#input\_cosmosdb\_enable\_public\_access) | A flag to indicate if the database can be accessed over the internet | `string` | `false` | no |
 | <a name="input_cosmosdb_id"></a> [cosmosdb\_id](#input\_cosmosdb\_id) | The ID of the CosmosDB account | `string` | n/a | yes |
 | <a name="input_cosmosdb_subnet_id"></a> [cosmosdb\_subnet\_id](#input\_cosmosdb\_subnet\_id) | The ID of the subnet containing the Cosmos DB endpoint | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |

--- a/app/stacks/uk-south/appeals-service/app-service.tf
+++ b/app/stacks/uk-south/appeals-service/app-service.tf
@@ -3,10 +3,13 @@ module "app_services" {
 
   source = "../../../components/appeals-app-services"
 
+  api_timeout                                                                 = var.api_timeout
   app_insights_connection_string                                              = var.app_insights_connection_string
   app_insights_instrumentation_key                                            = var.app_insights_instrumentation_key
   app_service_plan_id                                                         = var.app_service_plan_id
   app_service_private_dns_zone_id                                             = data.azurerm_private_dns_zone.app_service.id
+  appeal_documents_primary_blob_connection_string                             = var.appeal_documents_primary_blob_connection_string
+  appeal_documents_storage_container_name                                     = var.appeal_documents_storage_container_name
   appeals_service_public_url                                                  = var.appeals_service_public_url
   container_registry_login_server                                             = data.azurerm_container_registry.acr.login_server
   container_registry_password                                                 = data.azurerm_container_registry.acr.admin_password
@@ -15,6 +18,8 @@ module "app_services" {
   endpoint_subnet_id                                                          = azurerm_subnet.appeals_service_ingress.id
   function_apps_storage_account                                               = var.function_apps_storage_account
   function_apps_storage_account_primary_access_key                            = var.function_apps_storage_account_primary_access_key
+  google_analytics_id                                                         = var.google_analytics_id
+  google_tag_manager_id                                                       = var.google_tag_manager_id
   integration_subnet_id                                                       = var.integration_subnet_id
   key_vault_id                                                                = var.key_vault_id
   key_vault_secret_refs                                                       = var.key_vault_secret_refs

--- a/app/stacks/uk-south/appeals-service/cosmosdb.tf
+++ b/app/stacks/uk-south/appeals-service/cosmosdb.tf
@@ -1,4 +1,6 @@
 resource "azurerm_private_endpoint" "cosmosdb" {
+  count = var.cosmosdb_enable_public_access ? 0 : 1
+
   name                = "pins-pe-${local.service_name}-appeals-db-${local.resource_suffix}"
   location            = azurerm_resource_group.appeals_service_stack.location
   resource_group_name = azurerm_resource_group.appeals_service_stack.name

--- a/app/stacks/uk-south/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-south/appeals-service/terragrunt.hcl
@@ -8,6 +8,8 @@ dependency "appeals_service_ukw" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
+    appeal_documents_primary_blob_connection_string  = "mock_connection_string"
+    appeal_documents_storage_container_name          = "mock_container_name"
     cosmosdb_connection_string                       = "mock_connection_string"
     cosmosdb_id                                      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     function_apps_storage_account                    = "mockstorageaccount"
@@ -55,6 +57,8 @@ inputs = {
   app_insights_connection_string                   = try(dependency.common_uks.outputs.app_insights_connection_string, null)
   app_insights_instrumentation_key                 = try(dependency.common_uks.outputs.app_insights_instrumentation_key, null)
   app_service_plan_id                              = try(dependency.common_uks.outputs.app_service_plan_id, null)
+  appeal_documents_primary_blob_connection_string  = dependency.appeals_service_ukw.outputs.appeal_documents_primary_blob_connection_string
+  appeal_documents_storage_container_name          = dependency.appeals_service_ukw.outputs.appeal_documents_storage_container_name
   common_resource_group_name                       = dependency.common_uks.outputs.common_resource_group_name
   common_vnet_cidr_blocks                          = dependency.common_uks.outputs.common_vnet_cidr_blocks
   common_vnet_name                                 = dependency.common_uks.outputs.common_vnet_name

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -1,3 +1,8 @@
+variable "api_timeout" {
+  description = "The timeout in milliseconds for API calls in the frontend apps"
+  type        = string
+}
+
 variable "app_insights_connection_string" {
   description = "The connection string to connect to an Application Insights resource"
   sensitive   = true
@@ -12,6 +17,16 @@ variable "app_insights_instrumentation_key" {
 
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
+  type        = string
+}
+
+variable "appeal_documents_primary_blob_connection_string" {
+  description = "The Appeal Documents Storage Account blob connection string associated with the primary location"
+  type        = string
+}
+
+variable "appeal_documents_storage_container_name" {
+  description = "The name of the Storage Container for Appeal Documents"
   type        = string
 }
 
@@ -79,6 +94,16 @@ variable "function_apps_storage_account" {
 variable "function_apps_storage_account_primary_access_key" {
   description = "The primary access key of the storage account used by the Function Apps"
   sensitive   = true
+  type        = string
+}
+
+variable "google_analytics_id" {
+  description = "The id used to connect the frontend app to Google Analytics"
+  type        = string
+}
+
+variable "google_tag_manager_id" {
+  description = "The id used to connect the frontend app to Google Tag Manager"
   type        = string
 }
 

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -66,6 +66,12 @@ variable "container_registry_rg" {
   type        = string
 }
 
+variable "cosmosdb_enable_public_access" {
+  description = "A flag to indicate if the database can be accessed over the internet"
+  type        = string
+  default     = false
+}
+
 variable "cosmosdb_id" {
   description = "The ID of the CosmosDB account"
   type        = string

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -22,6 +22,7 @@ variable "app_service_plan_id" {
 
 variable "appeal_documents_primary_blob_connection_string" {
   description = "The Appeal Documents Storage Account blob connection string associated with the primary location"
+  sensitive   = true
   type        = string
 }
 

--- a/app/stacks/uk-south/common/README.md
+++ b/app/stacks/uk-south/common/README.md
@@ -34,6 +34,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#input\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_cosmosdb_enable_public_access"></a> [cosmosdb\_enable\_public\_access](#input\_cosmosdb\_enable\_public\_access) | A flag to indicate if the database can be accessed over the internet | `string` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_is_dr_deployment"></a> [is\_dr\_deployment](#input\_is\_dr\_deployment) | A flag to indicate whether or not the infrastructure deployment is for a disaster recovery scenario | `bool` | `false` | no |

--- a/app/stacks/uk-south/common/networking.tf
+++ b/app/stacks/uk-south/common/networking.tf
@@ -2,6 +2,7 @@ module "networking" {
   source = "../../../components/networking"
 
   base_cidr_block                             = var.secondary_vnet_address_space
+  cosmosdb_enable_public_access               = var.cosmosdb_enable_public_access
   deploy_national_infrastructure_vnet_gateway = var.is_dr_deployment
   env_network_region_short                    = module.azure_region_uks.location_short
   environment                                 = var.environment

--- a/app/stacks/uk-south/common/variables.tf
+++ b/app/stacks/uk-south/common/variables.tf
@@ -9,6 +9,12 @@ variable "common_tags" {
   type        = map(string)
 }
 
+variable "cosmosdb_enable_public_access" {
+  description = "A flag to indicate if the database can be accessed over the internet"
+  type        = string
+  default     = false
+}
+
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
   type        = string

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -53,6 +53,7 @@ No requirements.
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
+| <a name="input_cosmosdb_enable_public_access"></a> [cosmosdb\_enable\_public\_access](#input\_cosmosdb\_enable\_public\_access) | A flag to indicate if the database can be accessed over the internet | `string` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
 | <a name="input_google_tag_manager_id"></a> [google\_tag\_manager\_id](#input\_google\_tag\_manager\_id) | The id used to connect the frontend app to Google Tag Manager | `string` | n/a | yes |

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -42,6 +42,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
 | <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
@@ -53,6 +54,8 @@ No requirements.
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
+| <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |
+| <a name="input_google_tag_manager_id"></a> [google\_tag\_manager\_id](#input\_google\_tag\_manager\_id) | The id used to connect the frontend app to Google Tag Manager | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
@@ -76,6 +79,7 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_service_urls"></a> [app\_service\_urls](#output\_app\_service\_urls) | A map of frontend app service URLs |
+| <a name="output_appeal_documents_primary_blob_connection_string"></a> [appeal\_documents\_primary\_blob\_connection\_string](#output\_appeal\_documents\_primary\_blob\_connection\_string) | The Appeal Documents Storage Account blob connection string associated with the primary location |
 | <a name="output_cosmosdb_connection_string"></a> [cosmosdb\_connection\_string](#output\_cosmosdb\_connection\_string) | The connection string used to connect to the MongoDB |
 | <a name="output_cosmosdb_id"></a> [cosmosdb\_id](#output\_cosmosdb\_id) | The ID of the Cosmos DB account |
 | <a name="output_function_apps_storage_account"></a> [function\_apps\_storage\_account](#output\_function\_apps\_storage\_account) | The name of the storage account used by the Function Apps |

--- a/app/stacks/uk-west/appeals-service/app-service.tf
+++ b/app/stacks/uk-west/appeals-service/app-service.tf
@@ -1,10 +1,13 @@
 module "app_services" {
   source = "../../../components/appeals-app-services"
 
+  api_timeout                                                                 = var.api_timeout
   app_insights_connection_string                                              = var.app_insights_connection_string
   app_insights_instrumentation_key                                            = var.app_insights_instrumentation_key
   app_service_plan_id                                                         = var.app_service_plan_id
   app_service_private_dns_zone_id                                             = data.azurerm_private_dns_zone.app_service.id
+  appeal_documents_primary_blob_connection_string                             = azurerm_storage_account.appeal_documents.primary_blob_connection_string
+  appeal_documents_storage_container_name                                     = azurerm_storage_container.documents.name
   appeals_service_public_url                                                  = var.appeals_service_public_url
   container_registry_login_server                                             = data.azurerm_container_registry.acr.login_server
   container_registry_password                                                 = data.azurerm_container_registry.acr.admin_password
@@ -13,6 +16,8 @@ module "app_services" {
   endpoint_subnet_id                                                          = azurerm_subnet.appeals_service_ingress.id
   function_apps_storage_account                                               = azurerm_storage_account.function_apps.name
   function_apps_storage_account_primary_access_key                            = azurerm_storage_account.function_apps.primary_connection_string
+  google_analytics_id                                                         = var.google_analytics_id
+  google_tag_manager_id                                                       = var.google_tag_manager_id
   integration_subnet_id                                                       = var.integration_subnet_id
   key_vault_id                                                                = var.key_vault_id
   key_vault_secret_refs                                                       = var.key_vault_secret_refs

--- a/app/stacks/uk-west/appeals-service/cosmosdb.tf
+++ b/app/stacks/uk-west/appeals-service/cosmosdb.tf
@@ -22,6 +22,10 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
   mongo_server_version = "3.6"
 
   capabilities {
+    name = "DisableRateLimitingResponses"
+  }
+
+  capabilities {
     name = "EnableMongo"
   }
 

--- a/app/stacks/uk-west/appeals-service/cosmosdb.tf
+++ b/app/stacks/uk-west/appeals-service/cosmosdb.tf
@@ -1,6 +1,7 @@
 resource "azurerm_cosmosdb_account" "appeals_database" {
   #TODO: Customer Managed Keys
   #checkov:skip=CKV_AZURE_100: Customer Managed Keys not implemented yet
+  #checkov:skip=CKV_AZURE_132: Allow metadata writes
   #checkov:skip=CKV_AZURE_140: Local authentication only applicable to SQL API
   name                = "pins-cosmos-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.appeals_service_stack.location
@@ -8,7 +9,7 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
   offer_type          = "Standard"
   kind                = "MongoDB"
 
-  access_key_metadata_writes_enabled = false
+  access_key_metadata_writes_enabled = true
   enable_automatic_failover          = true
   is_virtual_network_filter_enabled  = false
   #TODO: Private endpoint connection not working so this is enabled for now - Access restrictions done by firewall

--- a/app/stacks/uk-west/appeals-service/cosmosdb.tf
+++ b/app/stacks/uk-west/appeals-service/cosmosdb.tf
@@ -22,10 +22,6 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
   mongo_server_version = "3.6"
 
   capabilities {
-    name = "DisableRateLimitingResponses"
-  }
-
-  capabilities {
     name = "EnableMongo"
   }
 

--- a/app/stacks/uk-west/appeals-service/cosmosdb.tf
+++ b/app/stacks/uk-west/appeals-service/cosmosdb.tf
@@ -20,7 +20,6 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
   enable_automatic_failover          = true
   is_virtual_network_filter_enabled  = false
 
-
   # IP addresses to allow access from Azure Portal. See: https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-the-azure-portal
   ip_range_filter = var.cosmosdb_enable_public_access ? null : "104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26"
 

--- a/app/stacks/uk-west/appeals-service/cosmosdb.tf
+++ b/app/stacks/uk-west/appeals-service/cosmosdb.tf
@@ -3,6 +3,13 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
   #checkov:skip=CKV_AZURE_100: Customer Managed Keys not implemented yet
   #checkov:skip=CKV_AZURE_132: Allow metadata writes
   #checkov:skip=CKV_AZURE_140: Local authentication only applicable to SQL API
+
+  # Private endpoint connection is working, and access is restricted by the firewall. Turning off public network access seems to break
+  # the private connection too - looks like a bug in Azure, since when you create the account manually with a private connection the state shows
+  # that public_network_access_enabled is always set to true.
+  #checkov:skip=CKV_AZURE_99
+  #checkov:skip=CKV_AZURE_101
+
   name                = "pins-cosmos-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.appeals_service_stack.location
   resource_group_name = azurerm_resource_group.appeals_service_stack.name
@@ -12,13 +19,10 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
   access_key_metadata_writes_enabled = true
   enable_automatic_failover          = true
   is_virtual_network_filter_enabled  = false
-  #TODO: Private endpoint connection not working so this is enabled for now - Access restrictions done by firewall
-  #checkov:skip=CKV_AZURE_99
-  #checkov:skip=CKV_AZURE_101
-  public_network_access_enabled = true
+
 
   # IP addresses to allow access from Azure Portal. See: https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-the-azure-portal
-  ip_range_filter = "104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26"
+  ip_range_filter = var.cosmosdb_enable_public_access ? null : "104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26"
 
   mongo_server_version = "3.6"
 
@@ -54,6 +58,8 @@ resource "azurerm_cosmosdb_account" "appeals_database" {
 }
 
 resource "azurerm_private_endpoint" "cosmosdb" {
+  count = var.cosmosdb_enable_public_access ? 0 : 1
+
   name                = "pins-pe-${local.service_name}-appeals-db-${local.resource_suffix}"
   location            = azurerm_resource_group.appeals_service_stack.location
   resource_group_name = azurerm_resource_group.appeals_service_stack.name

--- a/app/stacks/uk-west/appeals-service/outputs.tf
+++ b/app/stacks/uk-west/appeals-service/outputs.tf
@@ -5,6 +5,7 @@ output "app_service_urls" {
 
 output "appeal_documents_primary_blob_connection_string" {
   description = "The Appeal Documents Storage Account blob connection string associated with the primary location"
+  sensitive   = true
   value       = azurerm_storage_account.appeal_documents.primary_blob_connection_string
 }
 

--- a/app/stacks/uk-west/appeals-service/outputs.tf
+++ b/app/stacks/uk-west/appeals-service/outputs.tf
@@ -3,6 +3,11 @@ output "app_service_urls" {
   value       = module.app_services.app_service_urls
 }
 
+output "appeal_documents_primary_blob_connection_string" {
+  description = "The Appeal Documents Storage Account blob connection string associated with the primary location"
+  value       = azurerm_storage_account.appeal_documents.primary_blob_connection_string
+}
+
 output "cosmosdb_connection_string" {
   description = "The connection string used to connect to the MongoDB"
   sensitive   = true

--- a/app/stacks/uk-west/appeals-service/storage-account.tf
+++ b/app/stacks/uk-west/appeals-service/storage-account.tf
@@ -21,7 +21,7 @@ resource "azurerm_storage_account" "appeal_documents" {
 resource "azurerm_storage_container" "documents" {
   #TODO: Logging
   #checkov:skip=CKV2_AZURE_21 Logging not implemented yet
-  name                  = "documents"
+  name                  = "uploads"
   storage_account_name  = azurerm_storage_account.appeal_documents.name
   container_access_type = "private"
 }

--- a/app/stacks/uk-west/appeals-service/variables.tf
+++ b/app/stacks/uk-west/appeals-service/variables.tf
@@ -1,3 +1,8 @@
+variable "api_timeout" {
+  description = "The timeout in milliseconds for API calls in the frontend apps"
+  type        = string
+}
+
 variable "app_insights_connection_string" {
   description = "The connection string to connect to an Application Insights resource"
   sensitive   = true
@@ -51,6 +56,16 @@ variable "container_registry_rg" {
 
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
+  type        = string
+}
+
+variable "google_analytics_id" {
+  description = "The id used to connect the frontend app to Google Analytics"
+  type        = string
+}
+
+variable "google_tag_manager_id" {
+  description = "The id used to connect the frontend app to Google Tag Manager"
   type        = string
 }
 

--- a/app/stacks/uk-west/appeals-service/variables.tf
+++ b/app/stacks/uk-west/appeals-service/variables.tf
@@ -54,6 +54,12 @@ variable "container_registry_rg" {
   type        = string
 }
 
+variable "cosmosdb_enable_public_access" {
+  description = "A flag to indicate if the database can be accessed over the internet"
+  type        = string
+  default     = false
+}
+
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
   type        = string

--- a/app/stacks/uk-west/common/README.md
+++ b/app/stacks/uk-west/common/README.md
@@ -41,6 +41,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | The common resource tags for the project | `map(string)` | n/a | yes |
+| <a name="input_cosmosdb_enable_public_access"></a> [cosmosdb\_enable\_public\_access](#input\_cosmosdb\_enable\_public\_access) | A flag to indicate if the database can be accessed over the internet | `string` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_front_door_principal_id"></a> [front\_door\_principal\_id](#input\_front\_door\_principal\_id) | The ID of the service principal associated with Front Door in the tenant | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |

--- a/app/stacks/uk-west/common/locals.tf
+++ b/app/stacks/uk-west/common/locals.tf
@@ -17,7 +17,7 @@ locals {
     "applications-service-mysql-password",
     "applications-service-mysql-port",
     "applications-service-mysql-username",
-    "microsoft_provider_authentication_secret",
+    "microsoft-provider-authentication-secret",
     "srv-notify-api-key"
   ]
 

--- a/app/stacks/uk-west/common/locals.tf
+++ b/app/stacks/uk-west/common/locals.tf
@@ -17,6 +17,7 @@ locals {
     "applications-service-mysql-password",
     "applications-service-mysql-port",
     "applications-service-mysql-username",
+    "microsoft_provider_authentication_secret",
     "srv-notify-api-key"
   ]
 

--- a/app/stacks/uk-west/common/networking.tf
+++ b/app/stacks/uk-west/common/networking.tf
@@ -2,6 +2,7 @@ module "networking" {
   source = "../../../components/networking"
 
   base_cidr_block                             = var.primary_vnet_address_space
+  cosmosdb_enable_public_access               = var.cosmosdb_enable_public_access
   deploy_national_infrastructure_vnet_gateway = true
   env_network_region_short                    = module.azure_region_ukw.location_short
   environment                                 = var.environment

--- a/app/stacks/uk-west/common/variables.tf
+++ b/app/stacks/uk-west/common/variables.tf
@@ -3,6 +3,12 @@ variable "common_tags" {
   type        = map(string)
 }
 
+variable "cosmosdb_enable_public_access" {
+  description = "A flag to indicate if the database can be accessed over the internet"
+  type        = string
+  default     = false
+}
+
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
   type        = string

--- a/config/variables/dev.hcl
+++ b/config/variables/dev.hcl
@@ -2,6 +2,7 @@ locals {
   api_timeout                     = 10000
   appeals_service_public_url      = "appeals-service-dev.planninginspectorate.gov.uk"
   applications_service_public_url = "applications-service-dev.planninginspectorate.gov.uk"
+  cosmosdb_enable_public_access   = true
   environment                     = "dev"
   logger_level                    = "info"
   node_environment                = "development"

--- a/config/variables/stacks/appeals-service/dev.hcl
+++ b/config/variables/stacks/appeals-service/dev.hcl
@@ -1,4 +1,6 @@
 locals {
+  google_analytics_id                                                         = "G-TZBWMVPTHV"
+  google_tag_manager_id                                                       = "GTM-KZN7XP4"
   srv_notify_appeal_submission_confirmation_email_to_apellant_template_id     = "72f71441-12bf-4455-afbc-c58f9c72bfbd"
   srv_notify_appeal_submission_received_notification_email_to_lpa_template_id = "79488d5d-7efd-4273-a11f-e73f11d19676"
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = "f1e6c8c5-786e-41ca-9086-10b67f31bc86"

--- a/config/variables/stacks/appeals-service/prod.hcl
+++ b/config/variables/stacks/appeals-service/prod.hcl
@@ -1,4 +1,6 @@
 locals {
+  google_analytics_id                                                         = "G-TZBWMVPTHV"
+  google_tag_manager_id                                                       = "GTM-KZN7XP4"
   srv_notify_appeal_submission_confirmation_email_to_apellant_template_id     = "72f71441-12bf-4455-afbc-c58f9c72bfbd"
   srv_notify_appeal_submission_received_notification_email_to_lpa_template_id = "79488d5d-7efd-4273-a11f-e73f11d19676"
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = "f1e6c8c5-786e-41ca-9086-10b67f31bc86"

--- a/config/variables/stacks/appeals-service/test.hcl
+++ b/config/variables/stacks/appeals-service/test.hcl
@@ -1,4 +1,6 @@
 locals {
+  google_analytics_id                                                         = "G-TZBWMVPTHV"
+  google_tag_manager_id                                                       = "GTM-KZN7XP4"
   srv_notify_appeal_submission_confirmation_email_to_apellant_template_id     = "72f71441-12bf-4455-afbc-c58f9c72bfbd"
   srv_notify_appeal_submission_received_notification_email_to_lpa_template_id = "79488d5d-7efd-4273-a11f-e73f11d19676"
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = "f1e6c8c5-786e-41ca-9086-10b67f31bc86"

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -61,7 +61,8 @@ extends:
         deploymentSteps:
           - script: |
               echo "##vso[build.addbuildtag]stack=${{ parameters.stack }}"
-            displayName: Add stack build tag
+              echo "##vso[build.addbuildtag]region=${{ parameters.location }}"
+            displayName: Add stack & region build tag
           - ${{ if eq(parameters.stack, 'all') }}:
             - template: ${{variables['Build.SourcesDirectory']}}/steps/terragrunt_plan_all.yml@templates
               parameters:


### PR DESCRIPTION
- Add app settings for remaining Appeals Service applications
- Changes some settings on CosmosDB the frontend needs
- Removes private endpoint on CosmosDB when in the Dev environment to allow connecting to the database via Compass
- Add region tag to deployments