### PR TITLE
Add production URL for the Applications service

### DIFF
--- a/config/variables/prod.hcl
+++ b/config/variables/prod.hcl
@@ -1,7 +1,7 @@
 locals {
   api_timeout                     = 10000
-  appeals_service_public_url      = "appeals-service-prod.planninginspectorate.gov.uk"      # "appeal-planning-decision.planninginspectorate.gov.uk"
-  applications_service_public_url = "applications-service-prod.planninginspectorate.gov.uk" # "www.national-infrastructure.planninginspectorate.gov.uk"
+  appeals_service_public_url      = "appeals-service-prod.planninginspectorate.gov.uk"
+  applications_service_public_url = "national-infrastructure-consenting.planninginspectorate.gov.uk"
   environment                     = "prod"
   logger_level                    = "info"
   monitoring_alerts_enabled       = true


### PR DESCRIPTION
- Update the Applications URL in the production environment to its established go-live URL.
- Remove redundant comments.