### PR TITLE
Add a separate SRV_NOTIFY secret for applications

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -73,7 +73,6 @@ No requirements.
 | <a name="input_srv_notify_email_reply_to_id_start_email_to_lpa_template_id"></a> [srv\_notify\_email\_reply\_to\_id\_start\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_email\_reply\_to\_id\_start\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_srv_notify_service_id"></a> [srv\_notify\_service\_id](#input\_srv\_notify\_service\_id) | The ID of the Notifications service | `string` | n/a | yes |
 | <a name="input_srv_notify_start_email_to_lpa_template_id"></a> [srv\_notify\_start\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_start\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
-| <a name="input_srv_notify_template_id"></a> [srv\_notify\_template\_id](#input\_srv\_notify\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags applied to all resources | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -84,7 +84,6 @@ locals {
         SRV_NOTIFY_EMAIL_REPLYTO_ID_START_EMAIL_TO_LPA                              = var.srv_notify_email_reply_to_id_start_email_to_lpa_template_id
         SRV_NOTIFY_SERVICE_ID                                                       = var.srv_notify_service_id
         SRV_NOTIFY_START_EMAIL_TO_LPA_TEMPLATE_ID                                   = var.srv_notify_start_email_to_lpa_template_id
-        SRV_NOTIFY_TEMPLATE_ID                                                      = var.srv_notify_template_id
       }
     }
 

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -28,7 +28,7 @@ locals {
         GOOGLE_TAG_MANAGER_ID                      = var.google_tag_manager_id
         HORIZON_HAS_PUBLISHER_ATTEMPT_RECONNECTION = true
         HOST_URL                                   = "https://${var.appeals_service_public_url}"
-        MICROSOFT_PROVIDER_AUTHENTICATION_SECRET   = var.key_vault_secret_refs["microsoft-provider-authentication-secret"]
+        MICROSOFT_PROVIDER_AUTHENTICATION_SECRET   = var.key_vault_secret_refs["appeals-microsoft-provider-authentication-secret"]
         PDF_SERVICE_API_URL                        = "https://pins-app-${var.service_name}-pdf-api-${var.resource_suffix}.azurewebsites.net"
         PORT                                       = "3000"
         SESSION_KEY                                = "some_key"
@@ -77,7 +77,7 @@ locals {
         SERVER_PORT                                                                 = "3000"
         SERVER_SHOW_ERRORS                                                          = true
         SERVER_TERMINATION_GRACE_PERIOD_SECONDS                                     = "0"
-        SRV_NOTIFY_API_KEY                                                          = var.key_vault_secret_refs["srv-notify-api-key"]
+        SRV_NOTIFY_API_KEY                                                          = var.key_vault_secret_refs["appeals-srv-notify-api-key"]
         SRV_NOTIFY_APPEAL_SUBMISSION_CONFIRMATION_EMAIL_TO_APPELLANT_TEMPLATE_ID    = var.srv_notify_appeal_submission_confirmation_email_to_apellant_template_id
         SRV_NOTIFY_APPEAL_SUBMISSION_RECEIVED_NOTIFICATION_EMAIL_TO_LPA_TEMPLATE_ID = var.srv_notify_appeal_submission_received_notification_email_to_lpa_template_id
         SRV_NOTIFY_BASE_URL                                                         = var.srv_notify_base_url

--- a/app/components/appeals-app-services/variables.tf
+++ b/app/components/appeals-app-services/variables.tf
@@ -183,11 +183,6 @@ variable "srv_notify_start_email_to_lpa_template_id" {
   type        = string
 }
 
-variable "srv_notify_template_id" {
-  description = "A template ID required by the Appeals Service API"
-  type        = string
-}
-
 variable "tags" {
   description = "The tags applied to all resources"
   type        = map(string)

--- a/app/components/applications-app-services/locals.tf
+++ b/app/components/applications-app-services/locals.tf
@@ -46,7 +46,7 @@ locals {
         SERVER_PORT                                         = "3000"
         SERVER_SHOW_ERRORS                                  = true
         SERVER_TERMINATION_GRACE_PERIOD_SECONDS             = "0"
-        SRV_NOTIFY_API_KEY                                  = var.key_vault_secret_refs["srv-notify-api-key"]
+        SRV_NOTIFY_API_KEY                                  = var.key_vault_secret_refs["applications-srv-notify-api-key"]
         SRV_NOTIFY_BASE_URL                                 = var.srv_notify_base_url
         SRV_NOTIFY_IP_REGISTRATION_CONFIRMATION_EMAIL_TO_IP = var.srv_notify_ip_registration_confirmation_email_to_ip_template_id
         SRV_NOTIFY_MAGIC_LINK_EMAIL                         = var.srv_notify_magic_link_email_template_id

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -63,7 +63,7 @@ No requirements.
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_is_dr_deployment"></a> [is\_dr\_deployment](#input\_is\_dr\_deployment) | A flag to indicate whether or not the infrastructure deployment is for a disaster recovery scenario | `bool` | `false` | no |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
-| <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
+| <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location resources are deployed to in slug format e.g. 'uk-west' | `string` | `"uk-south"` | no |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
@@ -74,7 +74,6 @@ No requirements.
 | <a name="input_srv_notify_email_reply_to_id_start_email_to_lpa_template_id"></a> [srv\_notify\_email\_reply\_to\_id\_start\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_email\_reply\_to\_id\_start\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_srv_notify_service_id"></a> [srv\_notify\_service\_id](#input\_srv\_notify\_service\_id) | The ID of the Notifications service | `string` | n/a | yes |
 | <a name="input_srv_notify_start_email_to_lpa_template_id"></a> [srv\_notify\_start\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_start\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
-| <a name="input_srv_notify_template_id"></a> [srv\_notify\_template\_id](#input\_srv\_notify\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |
 
 ## Outputs

--- a/app/stacks/uk-south/appeals-service/app-service.tf
+++ b/app/stacks/uk-south/appeals-service/app-service.tf
@@ -23,7 +23,7 @@ module "app_services" {
   horizon_url                                                                 = var.horizon_url
   integration_subnet_id                                                       = var.integration_subnet_id
   key_vault_id                                                                = var.key_vault_id
-  key_vault_secret_refs                                                       = var.key_vault_secret_refs
+  key_vault_secret_refs                                                       = local.secret_refs
   location                                                                    = azurerm_resource_group.appeals_service_stack.location
   logger_level                                                                = var.logger_level
   monitoring_alerts_enabled                                                   = var.monitoring_alerts_enabled
@@ -38,7 +38,6 @@ module "app_services" {
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = var.srv_notify_email_reply_to_id_start_email_to_lpa_template_id
   srv_notify_service_id                                                       = var.srv_notify_service_id
   srv_notify_start_email_to_lpa_template_id                                   = var.srv_notify_start_email_to_lpa_template_id
-  srv_notify_template_id                                                      = var.srv_notify_template_id
 
   tags = local.tags
 }

--- a/app/stacks/uk-south/appeals-service/locals.tf
+++ b/app/stacks/uk-south/appeals-service/locals.tf
@@ -1,6 +1,22 @@
 locals {
   service_name    = "appeals-service"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
+
+  secret_names = [
+    "applications-service-encryption-secret-key",
+    "applications-service-mysql-database",
+    "applications-service-mysql-dialect",
+    "applications-service-mysql-host",
+    "applications-service-mysql-password",
+    "applications-service-mysql-port",
+    "applications-service-mysql-username",
+    "applications-srv-notify-api-key"
+  ]
+
+  secret_refs = {
+    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${var.key_vault_uri}secrets/${name}/)"
+  }
+
   tags = merge(
     var.common_tags,
     {

--- a/app/stacks/uk-south/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-south/appeals-service/terragrunt.hcl
@@ -46,10 +46,7 @@ dependency "common_ukw" {
   mock_outputs = {
     action_group_low_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
     key_vault_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.KeyVault/vaults/mockvault"
-
-    key_vault_secret_refs = {
-      srv-notify-api-key = "mock_secret"
-    }
+    key_vault_uri       = "https://mockvault.vault.azure.net/"
   }
 }
 
@@ -69,5 +66,5 @@ inputs = {
   function_apps_storage_account                   = dependency.appeals_service_ukw.outputs.function_apps_storage_account
   integration_subnet_id                           = dependency.common_uks.outputs.integration_subnet_id
   key_vault_id                                    = dependency.common_ukw.outputs.key_vault_id
-  key_vault_secret_refs                           = dependency.common_ukw.outputs.key_vault_secret_refs
+  key_vault_uri                                   = dependency.common_ukw.outputs.key_vault_uri
 }

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -140,9 +140,9 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "key_vault_secret_refs" {
-  description = "Map of secret references from the Key Vault"
-  type        = map(string)
+variable "key_vault_uri" {
+  description = "The URI of the Key Vault"
+  type        = string
 }
 
 variable "location" {
@@ -195,11 +195,6 @@ variable "srv_notify_service_id" {
 }
 
 variable "srv_notify_start_email_to_lpa_template_id" {
-  description = "A template ID required by the Appeals Service API"
-  type        = string
-}
-
-variable "srv_notify_template_id" {
   description = "A template ID required by the Appeals Service API"
   type        = string
 }

--- a/app/stacks/uk-south/applications-service/README.md
+++ b/app/stacks/uk-south/applications-service/README.md
@@ -56,7 +56,7 @@ No requirements.
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_is_dr_deployment"></a> [is\_dr\_deployment](#input\_is\_dr\_deployment) | A flag to indicate whether or not the infrastructure deployment is for a disaster recovery scenario | `bool` | `false` | no |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
-| <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
+| <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location resources are deployed to in slug format e.g. 'uk-west' | `string` | `"uk-south"` | no |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |

--- a/app/stacks/uk-south/applications-service/app-service.tf
+++ b/app/stacks/uk-south/applications-service/app-service.tf
@@ -17,7 +17,7 @@ module "app_services" {
   google_analytics_id                                             = var.google_analytics_id
   integration_subnet_id                                           = var.integration_subnet_id
   key_vault_id                                                    = var.key_vault_id
-  key_vault_secret_refs                                           = var.key_vault_secret_refs
+  key_vault_secret_refs                                           = local.secret_refs
   location                                                        = azurerm_resource_group.applications_service_stack.location
   logger_level                                                    = var.logger_level
   monitoring_alerts_enabled                                       = var.monitoring_alerts_enabled

--- a/app/stacks/uk-south/applications-service/locals.tf
+++ b/app/stacks/uk-south/applications-service/locals.tf
@@ -1,6 +1,22 @@
 locals {
   service_name    = "applications-service"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
+
+  secret_names = [
+    "applications-service-encryption-secret-key",
+    "applications-service-mysql-database",
+    "applications-service-mysql-dialect",
+    "applications-service-mysql-host",
+    "applications-service-mysql-password",
+    "applications-service-mysql-port",
+    "applications-service-mysql-username",
+    "applications-srv-notify-api-key"
+  ]
+
+  secret_refs = {
+    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${var.key_vault_uri}secrets/${name}/)"
+  }
+
   tags = merge(
     var.common_tags,
     {

--- a/app/stacks/uk-south/applications-service/terragrunt.hcl
+++ b/app/stacks/uk-south/applications-service/terragrunt.hcl
@@ -23,7 +23,6 @@ dependency "common_uks" {
 }
 
 dependency "common_ukw" {
-
   config_path                             = "../../uk-west/common"
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs_merge_with_state           = true
@@ -31,17 +30,7 @@ dependency "common_ukw" {
   mock_outputs = {
     action_group_low_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
     key_vault_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.KeyVault/vaults/mockvault"
-
-    key_vault_secret_refs = {
-      applications-service-encryption-secret-key = "mock_secret"
-      applications-service-mysql-database        = "mock_secret"
-      applications-service-mysql-dialect         = "mock_secret"
-      applications-service-mysql-host            = "mock_secret"
-      applications-service-mysql-password        = "mock_secret"
-      applications-service-mysql-port            = "mock_secret"
-      applications-service-mysql-username        = "mock_secret"
-      srv-notify-api-key                         = "mock_secret"
-    }
+    key_vault_uri       = "https://mockvault.vault.azure.net/"
   }
 }
 
@@ -57,5 +46,5 @@ inputs = {
   common_vnet_name                            = dependency.common_uks.outputs.common_vnet_name
   integration_subnet_id                       = dependency.common_uks.outputs.integration_subnet_id
   key_vault_id                                = dependency.common_ukw.outputs.key_vault_id
-  key_vault_secret_refs                       = dependency.common_ukw.outputs.key_vault_secret_refs
+  key_vault_uri                               = dependency.common_ukw.outputs.key_vault_uri
 }

--- a/app/stacks/uk-south/applications-service/variables.tf
+++ b/app/stacks/uk-south/applications-service/variables.tf
@@ -103,9 +103,9 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "key_vault_secret_refs" {
-  description = "Map of secret references from the Key Vault"
-  type        = map(string)
+variable "key_vault_uri" {
+  description = "The URI of the Key Vault"
+  type        = string
 }
 
 variable "location" {

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -28,6 +28,7 @@ No requirements.
 |------|------|
 | [azurerm_advanced_threat_protection.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/advanced_threat_protection) | resource |
 | [azurerm_cosmosdb_account.appeals_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
+| [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_account.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
@@ -63,7 +64,7 @@ No requirements.
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
-| <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
+| <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
@@ -75,7 +76,6 @@ No requirements.
 | <a name="input_srv_notify_email_reply_to_id_start_email_to_lpa_template_id"></a> [srv\_notify\_email\_reply\_to\_id\_start\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_email\_reply\_to\_id\_start\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_srv_notify_service_id"></a> [srv\_notify\_service\_id](#input\_srv\_notify\_service\_id) | The ID of the Notifications service | `string` | n/a | yes |
 | <a name="input_srv_notify_start_email_to_lpa_template_id"></a> [srv\_notify\_start\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_start\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
-| <a name="input_srv_notify_template_id"></a> [srv\_notify\_template\_id](#input\_srv\_notify\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |
 
 ## Outputs

--- a/app/stacks/uk-west/appeals-service/app-service.tf
+++ b/app/stacks/uk-west/appeals-service/app-service.tf
@@ -21,7 +21,7 @@ module "app_services" {
   horizon_url                                                                 = var.horizon_url
   integration_subnet_id                                                       = var.integration_subnet_id
   key_vault_id                                                                = var.key_vault_id
-  key_vault_secret_refs                                                       = var.key_vault_secret_refs
+  key_vault_secret_refs                                                       = local.secret_refs
   location                                                                    = module.azure_region_primary.location
   logger_level                                                                = var.logger_level
   monitoring_alerts_enabled                                                   = var.monitoring_alerts_enabled
@@ -36,7 +36,6 @@ module "app_services" {
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = var.srv_notify_email_reply_to_id_start_email_to_lpa_template_id
   srv_notify_service_id                                                       = var.srv_notify_service_id
   srv_notify_start_email_to_lpa_template_id                                   = var.srv_notify_start_email_to_lpa_template_id
-  srv_notify_template_id                                                      = var.srv_notify_template_id
 
   tags = local.tags
 }

--- a/app/stacks/uk-west/appeals-service/locals.tf
+++ b/app/stacks/uk-west/appeals-service/locals.tf
@@ -1,6 +1,16 @@
 locals {
   service_name    = "appeals-service"
   resource_suffix = "${var.environment}-${module.azure_region_primary.location_short}-${var.instance}"
+
+  secret_names = [
+    "appeals-microsoft-provider-authentication-secret",
+    "appeals-srv-notify-api-key"
+  ]
+
+  secret_refs = {
+    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${var.key_vault_uri}secrets/${name}/)"
+  }
+
   tags = merge(
     var.common_tags,
     {

--- a/app/stacks/uk-west/appeals-service/secrets.tf
+++ b/app/stacks/uk-west/appeals-service/secrets.tf
@@ -1,0 +1,18 @@
+resource "azurerm_key_vault_secret" "app_secret" {
+  #checkov:skip=CKV_AZURE_41: TODO: Secret rotation
+  #checkov:skip=CKV_AZURE_114: No need to set content type via Terraform, as secrets to be updated in Portal
+  for_each = toset(local.secret_names)
+
+  key_vault_id = var.key_vault_id
+  name         = each.value
+  value        = "<enter_value>"
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [
+      value,
+      version
+    ]
+  }
+}

--- a/app/stacks/uk-west/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-west/appeals-service/terragrunt.hcl
@@ -22,9 +22,7 @@ dependency "common_ukw" {
     cosmosdb_subnet_id    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     integration_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     key_vault_id          = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.KeyVault/vaults/mockvault"
-    key_vault_secret_refs = {
-      srv-notify-api-key = "mock_secret"
-    }
+    key_vault_uri         = "https://mockvault.vault.azure.net/"
   }
 }
 
@@ -39,5 +37,5 @@ inputs = {
   cosmosdb_subnet_id               = try(dependency.common_ukw.outputs.cosmosdb_subnet_id, null)
   integration_subnet_id            = dependency.common_ukw.outputs.integration_subnet_id
   key_vault_id                     = dependency.common_ukw.outputs.key_vault_id
-  key_vault_secret_refs            = dependency.common_ukw.outputs.key_vault_secret_refs
+  key_vault_uri                    = dependency.common_ukw.outputs.key_vault_uri
 }

--- a/app/stacks/uk-west/appeals-service/variables.tf
+++ b/app/stacks/uk-west/appeals-service/variables.tf
@@ -106,9 +106,9 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "key_vault_secret_refs" {
-  description = "Map of secret references from the Key Vault"
-  type        = map(string)
+variable "key_vault_uri" {
+  description = "The URI of the Key Vault"
+  type        = string
 }
 
 variable "logger_level" {
@@ -167,11 +167,6 @@ variable "srv_notify_service_id" {
 }
 
 variable "srv_notify_start_email_to_lpa_template_id" {
-  description = "A template ID required by the Appeals Service API"
-  type        = string
-}
-
-variable "srv_notify_template_id" {
   description = "A template ID required by the Appeals Service API"
   type        = string
 }

--- a/app/stacks/uk-west/applications-service/README.md
+++ b/app/stacks/uk-west/applications-service/README.md
@@ -25,6 +25,7 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
@@ -55,7 +56,7 @@ No requirements.
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
-| <a name="input_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#input\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault | `map(string)` | n/a | yes |
+| <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-west"` | no |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |

--- a/app/stacks/uk-west/applications-service/app-service.tf
+++ b/app/stacks/uk-west/applications-service/app-service.tf
@@ -15,7 +15,7 @@ module "app_services" {
   google_analytics_id                                             = var.google_analytics_id
   integration_subnet_id                                           = var.integration_subnet_id
   key_vault_id                                                    = var.key_vault_id
-  key_vault_secret_refs                                           = var.key_vault_secret_refs
+  key_vault_secret_refs                                           = local.secret_refs
   location                                                        = azurerm_resource_group.applications_service_stack.location
   monitoring_alerts_enabled                                       = var.monitoring_alerts_enabled
   logger_level                                                    = var.logger_level

--- a/app/stacks/uk-west/applications-service/locals.tf
+++ b/app/stacks/uk-west/applications-service/locals.tf
@@ -1,6 +1,22 @@
 locals {
   service_name    = "applications-service"
   resource_suffix = "${var.environment}-${module.azure_region_ukw.location_short}-${var.instance}"
+
+  secret_names = [
+    "applications-service-encryption-secret-key",
+    "applications-service-mysql-database",
+    "applications-service-mysql-dialect",
+    "applications-service-mysql-host",
+    "applications-service-mysql-password",
+    "applications-service-mysql-port",
+    "applications-service-mysql-username",
+    "applications-srv-notify-api-key"
+  ]
+
+  secret_refs = {
+    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${var.key_vault_uri}secrets/${name}/)"
+  }
+
   tags = merge(
     var.common_tags,
     {

--- a/app/stacks/uk-west/applications-service/secrets.tf
+++ b/app/stacks/uk-west/applications-service/secrets.tf
@@ -1,0 +1,18 @@
+resource "azurerm_key_vault_secret" "app_secret" {
+  #checkov:skip=CKV_AZURE_41: TODO: Secret rotation
+  #checkov:skip=CKV_AZURE_114: No need to set content type via Terraform, as secrets to be updated in Portal
+  for_each = toset(local.secret_names)
+
+  key_vault_id = var.key_vault_id
+  name         = each.value
+  value        = "<enter_value>"
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [
+      value,
+      version
+    ]
+  }
+}

--- a/app/stacks/uk-west/applications-service/terragrunt.hcl
+++ b/app/stacks/uk-west/applications-service/terragrunt.hcl
@@ -25,16 +25,7 @@ dependency "common" {
     common_vnet_name       = "mock_vnet_name"
     integration_subnet_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     key_vault_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.KeyVault/vaults/mockvault"
-    key_vault_secret_refs = {
-      applications-service-encryption-secret-key = "mock_secret"
-      applications-service-mysql-database        = "mock_secret"
-      applications-service-mysql-dialect         = "mock_secret"
-      applications-service-mysql-host            = "mock_secret"
-      applications-service-mysql-password        = "mock_secret"
-      applications-service-mysql-port            = "mock_secret"
-      applications-service-mysql-username        = "mock_secret"
-      srv-notify-api-key                         = "mock_secret"
-    }
+    key_vault_uri          = "@Microsoft.KeyVault(SecretUri=https://mockvault.vault.azure.net/secrets/mocksecret/)"
   }
 }
 
@@ -50,5 +41,5 @@ inputs = {
   common_vnet_name                            = dependency.common.outputs.common_vnet_name
   integration_subnet_id                       = dependency.common.outputs.integration_subnet_id
   key_vault_id                                = dependency.common.outputs.key_vault_id
-  key_vault_secret_refs                       = dependency.common.outputs.key_vault_secret_refs
+  key_vault_uri                               = dependency.common.outputs.key_vault_uri
 }

--- a/app/stacks/uk-west/applications-service/terragrunt.hcl
+++ b/app/stacks/uk-west/applications-service/terragrunt.hcl
@@ -15,9 +15,7 @@ dependency "common" {
     applications_service_vpn_gateway_shared_key = "mock_shared_key"
     common_resource_group_name                  = "mock_resource_group_name"
     common_vnet_cidr_blocks = {
-      app_gateway                    = "10.1.0.0/25"
       app_service_integration        = "10.1.1.0/24"
-      appeals_service_endpoints      = "10.1.2.0/24"
       applications_service_endpoints = "10.1.3.0/24"
       vpn_gateway                    = "10.1.0.128/25"
     }
@@ -25,7 +23,7 @@ dependency "common" {
     common_vnet_name       = "mock_vnet_name"
     integration_subnet_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/mock/mock_id"
     key_vault_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.KeyVault/vaults/mockvault"
-    key_vault_uri          = "@Microsoft.KeyVault(SecretUri=https://mockvault.vault.azure.net/secrets/mocksecret/)"
+    key_vault_uri          = "https://mockvault.vault.azure.net/"
   }
 }
 

--- a/app/stacks/uk-west/applications-service/variables.tf
+++ b/app/stacks/uk-west/applications-service/variables.tf
@@ -97,9 +97,9 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "key_vault_secret_refs" {
-  description = "Map of secret references from the Key Vault"
-  type        = map(string)
+variable "key_vault_uri" {
+  description = "The URI of the Key Vault"
+  type        = string
 }
 
 variable "location" {

--- a/app/stacks/uk-west/common/README.md
+++ b/app/stacks/uk-west/common/README.md
@@ -30,7 +30,6 @@ No requirements.
 | [azurerm_key_vault_access_policy.frontdoor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.terraform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.applications_service_vpn_gateway_shared_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_monitor_action_group.low](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_resource_group.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_service_plan.common_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
@@ -69,6 +68,6 @@ No requirements.
 | <a name="output_cosmosdb_subnet_id"></a> [cosmosdb\_subnet\_id](#output\_cosmosdb\_subnet\_id) | The id of the Cosmos DB endpoint subnet |
 | <a name="output_integration_subnet_id"></a> [integration\_subnet\_id](#output\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic |
 | <a name="output_key_vault_id"></a> [key\_vault\_id](#output\_key\_vault\_id) | The ID of the key vault so App Services can pull secret values |
-| <a name="output_key_vault_secret_refs"></a> [key\_vault\_secret\_refs](#output\_key\_vault\_secret\_refs) | Map of secret references from the Key Vault |
+| <a name="output_key_vault_uri"></a> [key\_vault\_uri](#output\_key\_vault\_uri) | The URI of the Key Vault |
 | <a name="output_vnet_id"></a> [vnet\_id](#output\_vnet\_id) | The ID of the Virtual Network |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/uk-west/common/key-vault.tf
+++ b/app/stacks/uk-west/common/key-vault.tf
@@ -67,26 +67,3 @@ resource "azurerm_key_vault_secret" "applications_service_vpn_gateway_shared_key
     ]
   }
 }
-
-resource "azurerm_key_vault_secret" "secret" {
-  #checkov:skip=CKV_AZURE_41: TODO: Secret rotation
-  #checkov:skip=CKV_AZURE_114: No need to set content type via Terraform, as secrets to be updated in Portal
-  for_each = toset(local.secret_names)
-
-  key_vault_id = azurerm_key_vault.environment_key_vault.id
-  name         = each.value
-  value        = "<enter_value>"
-
-  tags = local.tags
-
-  depends_on = [
-    azurerm_key_vault_access_policy.terraform
-  ]
-
-  lifecycle {
-    ignore_changes = [
-      value,
-      version
-    ]
-  }
-}

--- a/app/stacks/uk-west/common/locals.tf
+++ b/app/stacks/uk-west/common/locals.tf
@@ -1,6 +1,7 @@
 locals {
   service_name    = "common"
   resource_suffix = "${var.environment}-${module.azure_region_ukw.location_short}-${var.instance}"
+
   tags = merge(
     var.common_tags,
     {
@@ -8,20 +9,4 @@ locals {
       ServiceName = local.service_name
     }
   )
-
-  secret_names = [
-    "applications-service-encryption-secret-key",
-    "applications-service-mysql-database",
-    "applications-service-mysql-dialect",
-    "applications-service-mysql-host",
-    "applications-service-mysql-password",
-    "applications-service-mysql-port",
-    "applications-service-mysql-username",
-    "microsoft-provider-authentication-secret",
-    "srv-notify-api-key"
-  ]
-
-  secret_refs = {
-    for name in local.secret_names : name => "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.environment_key_vault.vault_uri}secrets/${name}/)"
-  }
 }

--- a/app/stacks/uk-west/common/outputs.tf
+++ b/app/stacks/uk-west/common/outputs.tf
@@ -61,9 +61,9 @@ output "key_vault_id" {
   value       = azurerm_key_vault.environment_key_vault.id
 }
 
-output "key_vault_secret_refs" {
-  description = "Map of secret references from the Key Vault"
-  value       = local.secret_refs
+output "key_vault_uri" {
+  description = "The URI of the Key Vault"
+  value       = azurerm_key_vault.environment_key_vault.vault_uri
 }
 
 output "vnet_id" {

--- a/config/variables/stacks/appeals-service/dev.hcl
+++ b/config/variables/stacks/appeals-service/dev.hcl
@@ -7,5 +7,4 @@ locals {
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = "f1e6c8c5-786e-41ca-9086-10b67f31bc86"
   srv_notify_service_id                                                       = "c46d894e-d10e-4c46-a467-019576cd906a"
   srv_notify_start_email_to_lpa_template_id                                   = "c4701212-4b6a-4b55-801a-c86c7dbea54b"
-  srv_notify_template_id                                                      = "15ed37a9-506c-4845-88ea-95502282a863"
 }

--- a/config/variables/stacks/appeals-service/prod.hcl
+++ b/config/variables/stacks/appeals-service/prod.hcl
@@ -7,5 +7,4 @@ locals {
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = "f1e6c8c5-786e-41ca-9086-10b67f31bc86"
   srv_notify_service_id                                                       = "c46d894e-d10e-4c46-a467-019576cd906a"
   srv_notify_start_email_to_lpa_template_id                                   = "c4701212-4b6a-4b55-801a-c86c7dbea54b"
-  srv_notify_template_id                                                      = "15ed37a9-506c-4845-88ea-95502282a863"
 }

--- a/config/variables/stacks/appeals-service/test.hcl
+++ b/config/variables/stacks/appeals-service/test.hcl
@@ -7,5 +7,4 @@ locals {
   srv_notify_email_reply_to_id_start_email_to_lpa_template_id                 = "f1e6c8c5-786e-41ca-9086-10b67f31bc86"
   srv_notify_service_id                                                       = "c46d894e-d10e-4c46-a467-019576cd906a"
   srv_notify_start_email_to_lpa_template_id                                   = "c4701212-4b6a-4b55-801a-c86c7dbea54b"
-  srv_notify_template_id                                                      = "15ed37a9-506c-4845-88ea-95502282a863"
 }


### PR DESCRIPTION
- Separate SRV_NOTIFY_API_KEY vars for appeals and applications
- Removed SRV_NOTIFY_TEMPLATE_ID
- Moved secret refs into each stack so we're just outputting the key vault uri