### PR TITLE
Front door restriction null

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -4,7 +4,7 @@ config {
 
 plugin "azurerm" {
   enabled = true
-  version = "0.14.0"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 

--- a/app/components/appeals-app-services/app-service.tf
+++ b/app/components/appeals-app-services/app-service.tf
@@ -15,7 +15,7 @@ module "app_service" {
   container_registry_server_username = var.container_registry_username
   deployment_slot                    = var.use_deployment_slots
   endpoint_subnet_id                 = can(each.value["endpoint_subnet_id"]) ? each.value["endpoint_subnet_id"] : null
-  front_door_restriction             = each.value["front_door_restriction"]
+  front_door_restriction             = can(each.value["front_door_restriction"]) ? each.value["front_door_restriction"] : null
   image_name                         = each.value["image_name"]
   inbound_vnet_connectivity          = each.value["inbound_vnet_connectivity"]
   integration_subnet_id              = can(each.value["integration_subnet_id"]) ? each.value["integration_subnet_id"] : null

--- a/app/modules/node-app-service/variables.tf
+++ b/app/modules/node-app-service/variables.tf
@@ -68,6 +68,7 @@ variable "endpoint_subnet_id" {
 
 variable "front_door_restriction" {
   description = "Flag to indicate if the web app should be restricted so it can only be accessed via Front Door"
+  nullable    = false
   type        = bool
   default     = false
 }


### PR DESCRIPTION
- When we were passing in null for the front_door_restriction, the value was coming through as null instead of the default value. This is expected behaviour in terraform, unless you have `nullable = false` set on the input variable.
- Also had to upgrade TFLint to allow checks to pass on pre-commit