### PR TITLE
Fix paths to terraform modules in CI pipeline

### DIFF
--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -17,8 +17,11 @@ extends:
       - template: steps/terraform_tflint.yml@templates
         parameters:
           moduleDirectories:
+            - $(Build.Repository.LocalPath)/app/components
             - $(Build.Repository.LocalPath)/app/modules
-            - $(Build.Repository.LocalPath)/app/stacks
+            - $(Build.Repository.LocalPath)/app/stacks/global
+            - $(Build.Repository.LocalPath)/app/stacks/uk-south
+            - $(Build.Repository.LocalPath)/app/stacks/uk-west
       - template: steps/run_checkov.yml@templates
       - template: steps/terragrunt_validate_all.yml@templates
         parameters:


### PR DESCRIPTION
- Since we introduced the components folder and the concept of regions, the paths to some modules in the TFLint build step were broken