### PR TITLE
SQL server AAD admin and short-term database retention policy

### DIFF
--- a/app/stacks/uk-south/back-office/README.md
+++ b/app/stacks/uk-south/back-office/README.md
@@ -58,6 +58,7 @@ No requirements.
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
 | <a name="input_primary_sql_server_id"></a> [primary\_sql\_server\_id](#input\_primary\_sql\_server\_id) | The ID of the primary Back Office SQL server | `string` | n/a | yes |
+| <a name="input_sql_server_azuread_administrator"></a> [sql\_server\_azuread\_administrator](#input\_sql\_server\_azuread\_administrator) | A map describing the AzureAD account used for the SQL server administrator | `map(string)` | n/a | yes |
 | <a name="input_sql_server_password"></a> [sql\_server\_password](#input\_sql\_server\_password) | The SQL server administrator password | `string` | n/a | yes |
 | <a name="input_sql_server_username"></a> [sql\_server\_username](#input\_sql\_server\_username) | The SQL server administrator username | `string` | n/a | yes |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |

--- a/app/stacks/uk-south/back-office/database.tf
+++ b/app/stacks/uk-south/back-office/database.tf
@@ -10,6 +10,11 @@ resource "azurerm_mssql_server" "back_office" {
   administrator_login_password = var.sql_server_password
   minimum_tls_version          = "1.2"
 
+  azuread_administrator {
+    login_username = var.sql_server_azuread_administrator["login_username"]
+    object_id      = var.sql_server_azuread_administrator["object_id"]
+  }
+
   tags = local.tags
 }
 

--- a/app/stacks/uk-south/back-office/variables.tf
+++ b/app/stacks/uk-south/back-office/variables.tf
@@ -105,6 +105,11 @@ variable "primary_sql_server_id" {
   type        = string
 }
 
+variable "sql_server_azuread_administrator" {
+  description = "A map describing the AzureAD account used for the SQL server administrator"
+  type        = map(string)
+}
+
 variable "sql_server_password" {
   description = "The SQL server administrator password"
   sensitive   = true

--- a/app/stacks/uk-west/back-office/README.md
+++ b/app/stacks/uk-west/back-office/README.md
@@ -53,7 +53,6 @@ No requirements.
 | <a name="input_common_vnet_name"></a> [common\_vnet\_name](#input\_common\_vnet\_name) | The common infrastructure virtual network name | `string` | n/a | yes |
 | <a name="input_container_registry_name"></a> [container\_registry\_name](#input\_container\_registry\_name) | The name of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
-| <a name="input_database_size"></a> [database\_size](#input\_database\_size) | A map of database sizing options | `map(string)` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment resources are deployed to e.g. 'dev' | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The environment instance for use if multiple environments are deployed to a subscription | `string` | `"001"` | no |
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | n/a | yes |
@@ -61,6 +60,8 @@ No requirements.
 | <a name="input_location"></a> [location](#input\_location) | The location resources are deployed to in slug format e.g. 'uk-south' | `string` | `"uk-west"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
+| <a name="input_sql_database_configuration"></a> [sql\_database\_configuration](#input\_sql\_database\_configuration) | A map of database configuration options | `map(string)` | n/a | yes |
+| <a name="input_sql_server_azuread_administrator"></a> [sql\_server\_azuread\_administrator](#input\_sql\_server\_azuread\_administrator) | A map describing the AzureAD account used for the SQL server administrator | `map(string)` | n/a | yes |
 | <a name="input_tooling_subscription_id"></a> [tooling\_subscription\_id](#input\_tooling\_subscription\_id) | The ID for the Tooling subscription that houses the Container Registry | `string` | n/a | yes |
 | <a name="input_use_deployment_slots"></a> [use\_deployment\_slots](#input\_use\_deployment\_slots) | Flag to indicate if App Service deployment slots are in use on the environment | `bool` | `true` | no |
 

--- a/app/stacks/uk-west/back-office/database.tf
+++ b/app/stacks/uk-west/back-office/database.tf
@@ -44,6 +44,11 @@ resource "azurerm_mssql_server" "back_office" {
   administrator_login_password = random_password.back_office_sql_server_password.result
   minimum_tls_version          = "1.2"
 
+  azuread_administrator {
+    login_username = var.sql_server_azuread_administrator["login_username"]
+    object_id      = var.sql_server_azuread_administrator["object_id"]
+  }
+
   depends_on = [
     azurerm_key_vault_secret.back_office_sql_server_username,
     azurerm_key_vault_secret.back_office_sql_server_password
@@ -76,8 +81,12 @@ resource "azurerm_mssql_database" "back_office" {
   server_id    = azurerm_mssql_server.back_office.id
   collation    = "SQL_Latin1_General_CP1_CI_AS"
   license_type = "LicenseIncluded"
-  sku_name     = var.database_size["sku_name"]
-  max_size_gb  = var.database_size["max_size_gb"]
+  sku_name     = var.sql_database_configuration["sku_name"]
+  max_size_gb  = var.sql_database_configuration["max_size_gb"]
+
+  short_term_retention_policy {
+    retention_days = var.sql_database_configuration["short_term_retention_days"]
+  }
 
   tags = local.tags
 }

--- a/app/stacks/uk-west/back-office/locals.tf
+++ b/app/stacks/uk-west/back-office/locals.tf
@@ -1,6 +1,6 @@
 locals {
   service_name          = "back-office"
-  sql_connection_string = "sqlserver://${azurerm_mssql_server.back_office.fully_qualified_domain_name};database=${azurerm_mssql_database.back_office.name};user=${azurerm_mssql_server.back_office.administrator_login};password=${urlencode(azurerm_mssql_server.back_office.administrator_login_password)};trustServerCertificate=true"
+  sql_connection_string = "sqlserver://${azurerm_mssql_server.back_office.fully_qualified_domain_name};database=${azurerm_mssql_database.back_office.name};user=${azurerm_mssql_server.back_office.administrator_login};password=${azurerm_mssql_server.back_office.administrator_login_password};trustServerCertificate=true"
   sql_server_username   = "backofficeadmin_${random_id.username_suffix.id}"
   resource_suffix       = "${var.environment}-${module.azure_region_ukw.location_short}-${var.instance}"
 

--- a/app/stacks/uk-west/back-office/variables.tf
+++ b/app/stacks/uk-west/back-office/variables.tf
@@ -50,11 +50,6 @@ variable "container_registry_rg" {
   type        = string
 }
 
-variable "database_size" {
-  description = "A map of database sizing options"
-  type        = map(string)
-}
-
 variable "environment" {
   description = "The environment resources are deployed to e.g. 'dev'"
   type        = string
@@ -92,6 +87,16 @@ variable "node_environment" {
   description = "The node environment to be used for applications in this environment e.g. development"
   type        = string
   default     = "development"
+}
+
+variable "sql_database_configuration" {
+  description = "A map of database configuration options"
+  type        = map(string)
+}
+
+variable "sql_server_azuread_administrator" {
+  description = "A map describing the AzureAD account used for the SQL server administrator"
+  type        = map(string)
 }
 
 variable "tooling_subscription_id" {

--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -1,6 +1,11 @@
 locals {
-  database_size = {
-    sku_name    = "Basic"
-    max_size_gb = 2
+  sql_database_configuration = {
+    max_size_gb               = 2
+    short_term_retention_days = 30 # 7-35
+    sku_name                  = "Basic"
+  }
+  sql_server_azuread_administrator = {
+    login_username = "sulmarch"
+    object_id      = "42523fcb-4a32-4910-8caa-4d310c7bfd55" # sulmarch@pinso365.onmicrosoft.com
   }
 }

--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -1,7 +1,7 @@
 locals {
   sql_database_configuration = {
     max_size_gb               = 2
-    short_term_retention_days = 30 # 7-35
+    short_term_retention_days = 7 # 7-35
     sku_name                  = "Basic"
   }
   sql_server_azuread_administrator = {

--- a/config/variables/stacks/back-office/prod.hcl
+++ b/config/variables/stacks/back-office/prod.hcl
@@ -1,6 +1,11 @@
 locals {
-  database_size = {
-    sku_name    = "GP_S_Gen5_2"
-    max_size_gb = 1024
+  sql_database_configuration = {
+    max_size_gb               = 1024
+    short_term_retention_days = 30 # 7-35
+    sku_name                  = "GP_S_Gen5_2"
+  }
+  sql_server_azuread_administrator = {
+    login_username = "sulmarch"
+    object_id      = "42523fcb-4a32-4910-8caa-4d310c7bfd55" # sulmarch@pinso365.onmicrosoft.com
   }
 }

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -1,6 +1,11 @@
 locals {
-  database_size = {
-    sku_name    = "Basic"
-    max_size_gb = 2
+  sql_database_configuration = {
+    max_size_gb               = 2
+    short_term_retention_days = 30 # 7-35
+    sku_name                  = "Basic"
+  }
+  sql_server_azuread_administrator = {
+    login_username = "sulmarch"
+    object_id      = "42523fcb-4a32-4910-8caa-4d310c7bfd55" # sulmarch@pinso365.onmicrosoft.com
   }
 }

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -1,7 +1,7 @@
 locals {
   sql_database_configuration = {
     max_size_gb               = 2
-    short_term_retention_days = 30 # 7-35
+    short_term_retention_days = 7 # 7-35
     sku_name                  = "Basic"
   }
   sql_server_azuread_administrator = {


### PR DESCRIPTION
- Add an AAD administrator assignment to the Back Office SQL server in addition to the local SQL administrator.
- Add a short-term retention policy, configurable per environment, to the Back Office database.
- Remove URL encoding for the database connection string to fix authentication.