### PR TITLE
Set all environments to DTU-based SQL billing

### DIFF
--- a/config/variables/stacks/back-office/prod.hcl
+++ b/config/variables/stacks/back-office/prod.hcl
@@ -2,7 +2,7 @@ locals {
   sql_database_configuration = {
     max_size_gb               = 1024
     short_term_retention_days = 30 # 7-35
-    sku_name                  = "GP_S_Gen5_2"
+    sku_name                  = "S3"
   }
   sql_server_azuread_administrator = {
     login_username = "sulmarch"

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -1,8 +1,8 @@
 locals {
   sql_database_configuration = {
-    max_size_gb               = 2
+    max_size_gb               = 1024
     short_term_retention_days = 7 # 7-35
-    sku_name                  = "Basic"
+    sku_name                  = "S3"
   }
   sql_server_azuread_administrator = {
     login_username = "sulmarch"


### PR DESCRIPTION
- Update the Production environment Azure SQL Database SKU to `S3` with 1TB capacity.
- Update the Test environment Azure SQL Database SKU to `S3` with 1TB capacity.
- Dev environment remains on the `Basic` DTU SKU with 2GB capacity.