### PR TITLE
Fix action group name due to character limit

### DIFF
--- a/app/stacks/uk-west/back-office/database.tf
+++ b/app/stacks/uk-west/back-office/database.tf
@@ -46,14 +46,13 @@ resource "azurerm_mssql_server" "back_office" {
   #checkov:skip=CKV_AZURE_113: Public access enabled for testing
   #checkov:skip=CKV_AZURE_23: Auditing to be added later
   #checkov:skip=CKV_AZURE_24: Auditing to be added later
-  name                          = "pins-sql-${local.service_name}-${local.resource_suffix}"
-  resource_group_name           = azurerm_resource_group.back_office_stack.name
-  location                      = azurerm_resource_group.back_office_stack.location
-  version                       = "12.0"
-  administrator_login           = local.sql_server_username
-  administrator_login_password  = random_password.back_office_sql_server_password.result
-  minimum_tls_version           = "1.2"
-  public_network_access_enabled = false
+  name                         = "pins-sql-${local.service_name}-${local.resource_suffix}"
+  resource_group_name          = azurerm_resource_group.back_office_stack.name
+  location                     = azurerm_resource_group.back_office_stack.location
+  version                      = "12.0"
+  administrator_login          = local.sql_server_username
+  administrator_login_password = random_password.back_office_sql_server_password.result
+  minimum_tls_version          = "1.2"
 
   azuread_administrator {
     login_username = var.sql_server_azuread_administrator["login_username"]

--- a/app/stacks/uk-west/back-office/database.tf
+++ b/app/stacks/uk-west/back-office/database.tf
@@ -46,13 +46,14 @@ resource "azurerm_mssql_server" "back_office" {
   #checkov:skip=CKV_AZURE_113: Public access enabled for testing
   #checkov:skip=CKV_AZURE_23: Auditing to be added later
   #checkov:skip=CKV_AZURE_24: Auditing to be added later
-  name                         = "pins-sql-${local.service_name}-${local.resource_suffix}"
-  resource_group_name          = azurerm_resource_group.back_office_stack.name
-  location                     = azurerm_resource_group.back_office_stack.location
-  version                      = "12.0"
-  administrator_login          = local.sql_server_username
-  administrator_login_password = random_password.back_office_sql_server_password.result
-  minimum_tls_version          = "1.2"
+  name                          = "pins-sql-${local.service_name}-${local.resource_suffix}"
+  resource_group_name           = azurerm_resource_group.back_office_stack.name
+  location                      = azurerm_resource_group.back_office_stack.location
+  version                       = "12.0"
+  administrator_login           = local.sql_server_username
+  administrator_login_password  = random_password.back_office_sql_server_password.result
+  minimum_tls_version           = "1.2"
+  public_network_access_enabled = false
 
   azuread_administrator {
     login_username = var.sql_server_azuread_administrator["login_username"]

--- a/app/stacks/uk-west/common/action-group.tf
+++ b/app/stacks/uk-west/common/action-group.tf
@@ -1,7 +1,7 @@
 resource "azurerm_monitor_action_group" "low" {
   name                = "pins-ag-low-${local.service_name}-${local.resource_suffix}"
   resource_group_name = azurerm_resource_group.common_infrastructure.name
-  short_name          = "pins-${var.environment}-low"
+  short_name          = "${var.environment}-low"
   tags                = local.tags
 
   dynamic "email_receiver" {


### PR DESCRIPTION
- Remove the `pins` prefix from the action group name to adhere to the action group `short_name` character limit.