### PR TITLE
Remove unused Service Bus queue

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -31,7 +31,6 @@ No requirements.
 | [azurerm_servicebus_namespace.horizon](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace) | resource |
 | [azurerm_servicebus_namespace_authorization_rule.horizon_function_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace_authorization_rule) | resource |
 | [azurerm_servicebus_queue.horizon_householder_appeal_publish](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_queue) | resource |
-| [azurerm_servicebus_queue.sql_householder_lpa_publish](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_queue) | resource |
 
 ## Inputs
 

--- a/app/components/appeals-app-services/service-bus.tf
+++ b/app/components/appeals-app-services/service-bus.tf
@@ -14,13 +14,6 @@ resource "azurerm_servicebus_queue" "horizon_householder_appeal_publish" {
   enable_partitioning = true
 }
 
-resource "azurerm_servicebus_queue" "sql_householder_lpa_publish" {
-  name         = "sql-householder-lpa-publish"
-  namespace_id = azurerm_servicebus_namespace.horizon.id
-
-  enable_partitioning = true
-}
-
 resource "azurerm_servicebus_namespace_authorization_rule" "horizon_function_apps" {
   name         = "horizon-function-apps"
   namespace_id = azurerm_servicebus_namespace.horizon.id


### PR DESCRIPTION
- Appeals no longer talks to an SQL database as this is part of the back office project. So there is no need to keep the queue as the function will be removed.