### PR TITLE
DBO-33: Send Log App Service Logs to Azure Monitor

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -41,8 +41,6 @@ This module also contains some resources such as Service Bus and Function Apps r
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority alerts | `string` | n/a | yes |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_service_private_dns_zone_id"></a> [app\_service\_private\_dns\_zone\_id](#input\_app\_service\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_appeal_documents_primary_blob_connection_string"></a> [appeal\_documents\_primary\_blob\_connection\_string](#input\_appeal\_documents\_primary\_blob\_connection\_string) | The Appeal Documents Storage Account blob connection string associated with the primary location | `string` | n/a | yes |
@@ -61,6 +59,7 @@ This module also contains some resources such as Service Bus and Function Apps r
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
 | <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location the App Services are deployed to in slug format e.g. 'uk-south' | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Azure Monitor Log Analytics Workspace | `string` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |

--- a/app/components/appeals-app-services/app-service.tf
+++ b/app/components/appeals-app-services/app-service.tf
@@ -3,28 +3,27 @@ module "app_service" {
 
   source = "../../modules/node-app-service"
 
-  action_group_low_id              = var.action_group_low_id
-  app_insights_connection_string   = var.app_insights_connection_string
-  app_insights_instrumentation_key = var.app_insights_instrumentation_key
-  app_name                         = each.value["app_name"]
-  app_service_plan_id              = var.app_service_plan_id
-  app_service_private_dns_zone_id  = can(each.value["app_service_private_dns_zone_id"]) ? each.value["app_service_private_dns_zone_id"] : null
-  app_settings                     = each.value["app_settings"]
-  container_registry_name          = var.container_registry_name
-  container_registry_rg            = var.container_registry_rg
-  deployment_slot                  = var.use_deployment_slots
-  endpoint_subnet_id               = can(each.value["endpoint_subnet_id"]) ? each.value["endpoint_subnet_id"] : null
-  front_door_restriction           = can(each.value["front_door_restriction"]) ? each.value["front_door_restriction"] : null
-  image_name                       = each.value["image_name"]
-  inbound_vnet_connectivity        = each.value["inbound_vnet_connectivity"]
-  integration_subnet_id            = can(each.value["integration_subnet_id"]) ? each.value["integration_subnet_id"] : null
-  key_vault_id                     = each.value["key_vault_access"] ? var.key_vault_id : null
-  location                         = var.location
-  monitoring_alerts_enabled        = var.monitoring_alerts_enabled
-  outbound_vnet_connectivity       = each.value["outbound_vnet_connectivity"]
-  resource_group_name              = var.resource_group_name
-  resource_suffix                  = var.resource_suffix
-  service_name                     = var.service_name
+  action_group_low_id             = var.action_group_low_id
+  app_name                        = each.value["app_name"]
+  app_service_plan_id             = var.app_service_plan_id
+  app_service_private_dns_zone_id = can(each.value["app_service_private_dns_zone_id"]) ? each.value["app_service_private_dns_zone_id"] : null
+  app_settings                    = each.value["app_settings"]
+  container_registry_name         = var.container_registry_name
+  container_registry_rg           = var.container_registry_rg
+  deployment_slot                 = var.use_deployment_slots
+  endpoint_subnet_id              = can(each.value["endpoint_subnet_id"]) ? each.value["endpoint_subnet_id"] : null
+  front_door_restriction          = can(each.value["front_door_restriction"]) ? each.value["front_door_restriction"] : null
+  image_name                      = each.value["image_name"]
+  inbound_vnet_connectivity       = each.value["inbound_vnet_connectivity"]
+  integration_subnet_id           = can(each.value["integration_subnet_id"]) ? each.value["integration_subnet_id"] : null
+  key_vault_id                    = each.value["key_vault_access"] ? var.key_vault_id : null
+  location                        = var.location
+  log_analytics_workspace_id      = var.log_analytics_workspace_id
+  monitoring_alerts_enabled       = var.monitoring_alerts_enabled
+  outbound_vnet_connectivity      = each.value["outbound_vnet_connectivity"]
+  resource_group_name             = var.resource_group_name
+  resource_suffix                 = var.resource_suffix
+  service_name                    = var.service_name
 
   tags = var.tags
 

--- a/app/components/appeals-app-services/function-app.tf
+++ b/app/components/appeals-app-services/function-app.tf
@@ -7,6 +7,7 @@ module "horizon_functions" {
   function_apps_storage_account            = var.function_apps_storage_account
   function_apps_storage_account_access_key = var.function_apps_storage_account_access_key
   location                                 = var.location
+  log_analytics_workspace_id               = var.log_analytics_workspace_id
   monitoring_alerts_enabled                = var.monitoring_alerts_enabled
   resource_group_name                      = var.resource_group_name
   resource_suffix                          = var.resource_suffix

--- a/app/components/appeals-app-services/function-app.tf
+++ b/app/components/appeals-app-services/function-app.tf
@@ -2,8 +2,6 @@ module "horizon_functions" {
   source = "../../modules/node-function-app"
 
   action_group_low_id                      = var.action_group_low_id
-  app_insights_connection_string           = var.app_insights_connection_string
-  app_insights_instrumentation_key         = var.app_insights_instrumentation_key
   app_name                                 = "horizon"
   app_service_plan_id                      = var.app_service_plan_id
   function_apps_storage_account            = var.function_apps_storage_account

--- a/app/components/appeals-app-services/variables.tf
+++ b/app/components/appeals-app-services/variables.tf
@@ -8,18 +8,6 @@ variable "api_timeout" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
   type        = string
@@ -110,6 +98,11 @@ variable "key_vault_uri" {
 
 variable "location" {
   description = "The location the App Services are deployed to in slug format e.g. 'uk-south'"
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Azure Monitor Log Analytics Workspace"
   type        = string
 }
 

--- a/app/components/applications-app-services/README.md
+++ b/app/components/applications-app-services/README.md
@@ -31,8 +31,6 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority alerts | `string` | n/a | yes |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_service_private_dns_zone_id"></a> [app\_service\_private\_dns\_zone\_id](#input\_app\_service\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
 | <a name="input_applications_service_public_url"></a> [applications\_service\_public\_url](#input\_applications\_service\_public\_url) | The public URL for the Applications Service frontend web app | `string` | n/a | yes |
@@ -44,6 +42,7 @@ No resources.
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
 | <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location the App Services are deployed to in slug format e.g. 'uk-south' | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Azure Monitor Log Analytics Workspace | `string` | n/a | yes |
 | <a name="input_logger_level"></a> [logger\_level](#input\_logger\_level) | The level of logging enabled for applications in the environment e.g. info | `string` | `"info"` | no |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |

--- a/app/components/applications-app-services/app-service.tf
+++ b/app/components/applications-app-services/app-service.tf
@@ -3,28 +3,27 @@ module "app_service" {
 
   source = "../../modules/node-app-service"
 
-  action_group_low_id              = var.action_group_low_id
-  app_insights_connection_string   = var.app_insights_connection_string
-  app_insights_instrumentation_key = var.app_insights_instrumentation_key
-  app_name                         = each.value["app_name"]
-  app_service_plan_id              = var.app_service_plan_id
-  app_service_private_dns_zone_id  = can(each.value["app_service_private_dns_zone_id"]) ? each.value["app_service_private_dns_zone_id"] : null
-  app_settings                     = each.value["app_settings"]
-  container_registry_name          = var.container_registry_name
-  container_registry_rg            = var.container_registry_rg
-  deployment_slot                  = var.use_deployment_slots
-  endpoint_subnet_id               = can(each.value["endpoint_subnet_id"]) ? each.value["endpoint_subnet_id"] : null
-  front_door_restriction           = can(each.value["front_door_restriction"]) ? each.value["front_door_restriction"] : null
-  image_name                       = each.value["image_name"]
-  inbound_vnet_connectivity        = each.value["inbound_vnet_connectivity"]
-  integration_subnet_id            = can(each.value["integration_subnet_id"]) ? each.value["integration_subnet_id"] : null
-  key_vault_id                     = each.value["key_vault_access"] ? var.key_vault_id : null
-  location                         = var.location
-  monitoring_alerts_enabled        = var.monitoring_alerts_enabled
-  outbound_vnet_connectivity       = each.value["outbound_vnet_connectivity"]
-  resource_group_name              = var.resource_group_name
-  resource_suffix                  = var.resource_suffix
-  service_name                     = var.service_name
+  action_group_low_id             = var.action_group_low_id
+  app_name                        = each.value["app_name"]
+  app_service_plan_id             = var.app_service_plan_id
+  app_service_private_dns_zone_id = can(each.value["app_service_private_dns_zone_id"]) ? each.value["app_service_private_dns_zone_id"] : null
+  app_settings                    = each.value["app_settings"]
+  container_registry_name         = var.container_registry_name
+  container_registry_rg           = var.container_registry_rg
+  deployment_slot                 = var.use_deployment_slots
+  endpoint_subnet_id              = can(each.value["endpoint_subnet_id"]) ? each.value["endpoint_subnet_id"] : null
+  front_door_restriction          = can(each.value["front_door_restriction"]) ? each.value["front_door_restriction"] : null
+  image_name                      = each.value["image_name"]
+  inbound_vnet_connectivity       = each.value["inbound_vnet_connectivity"]
+  integration_subnet_id           = can(each.value["integration_subnet_id"]) ? each.value["integration_subnet_id"] : null
+  key_vault_id                    = each.value["key_vault_access"] ? var.key_vault_id : null
+  location                        = var.location
+  log_analytics_workspace_id      = var.log_analytics_workspace_id
+  monitoring_alerts_enabled       = var.monitoring_alerts_enabled
+  outbound_vnet_connectivity      = each.value["outbound_vnet_connectivity"]
+  resource_group_name             = var.resource_group_name
+  resource_suffix                 = var.resource_suffix
+  service_name                    = var.service_name
 
   tags = var.tags
 

--- a/app/components/applications-app-services/variables.tf
+++ b/app/components/applications-app-services/variables.tf
@@ -8,18 +8,6 @@ variable "api_timeout" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_private_dns_zone_id" {
   description = "The id of the private DNS zone for App services"
   type        = string
@@ -72,6 +60,11 @@ variable "key_vault_uri" {
 
 variable "location" {
   description = "The location the App Services are deployed to in slug format e.g. 'uk-south'"
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Azure Monitor Log Analytics Workspace"
   type        = string
 }
 

--- a/app/components/back-office-app-services/README.md
+++ b/app/components/back-office-app-services/README.md
@@ -34,8 +34,6 @@ This module contains the App Services resources for the Back Office service. The
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority alerts | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_service_plan_resource_group_name"></a> [app\_service\_plan\_resource\_group\_name](#input\_app\_service\_plan\_resource\_group\_name) | The App Service Plan resource group name required for custom hostname certificate placement | `string` | `null` | no |
 | <a name="input_app_service_private_dns_zone_id"></a> [app\_service\_private\_dns\_zone\_id](#input\_app\_service\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |
@@ -53,6 +51,7 @@ This module contains the App Services resources for the Back Office service. The
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | n/a | yes |
 | <a name="input_key_vault_uri"></a> [key\_vault\_uri](#input\_key\_vault\_uri) | The URI of the Key Vault | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location the App Services are deployed to in slug format e.g. 'uk-south' | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Azure Monitor Log Analytics Workspace | `string` | n/a | yes |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
 | <a name="input_private_endpoint_enabled"></a> [private\_endpoint\_enabled](#input\_private\_endpoint\_enabled) | A switch to determine if Private Endpoint should be enabled for backend App Services | `bool` | `true` | no |

--- a/app/components/back-office-app-services/app-service.tf
+++ b/app/components/back-office-app-services/app-service.tf
@@ -4,8 +4,6 @@ module "app_service" {
   source = "../../modules/node-app-service"
 
   action_group_low_id                   = var.action_group_low_id
-  app_insights_connection_string        = var.app_insights_connection_string
-  app_insights_instrumentation_key      = var.app_insights_instrumentation_key
   app_name                              = each.value["app_name"]
   app_service_plan_id                   = var.app_service_plan_id
   app_service_plan_resource_group_name  = can(each.value["app_service_plan_resource_group_name"]) ? each.value["app_service_plan_resource_group_name"] : null
@@ -22,6 +20,7 @@ module "app_service" {
   integration_subnet_id                 = can(each.value["integration_subnet_id"]) ? each.value["integration_subnet_id"] : null
   key_vault_id                          = each.value["key_vault_access"] ? var.key_vault_id : null
   location                              = var.location
+  log_analytics_workspace_id            = var.log_analytics_workspace_id
   monitoring_alerts_enabled             = var.monitoring_alerts_enabled
   outbound_vnet_connectivity            = each.value["outbound_vnet_connectivity"]
   resource_group_name                   = var.resource_group_name

--- a/app/components/back-office-app-services/variables.tf
+++ b/app/components/back-office-app-services/variables.tf
@@ -3,18 +3,6 @@ variable "action_group_low_id" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_private_dns_zone_id" {
   description = "The id of the private DNS zone for App services"
   type        = string
@@ -105,6 +93,11 @@ variable "key_vault_uri" {
 
 variable "location" {
   description = "The location the App Services are deployed to in slug format e.g. 'uk-south'"
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Azure Monitor Log Analytics Workspace"
   type        = string
 }
 

--- a/app/modules/node-app-service/README.md
+++ b/app/modules/node-app-service/README.md
@@ -34,7 +34,7 @@ No modules.
 | [azurerm_linux_web_app_slot.staging](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/linux_web_app_slot) | resource |
 | [azurerm_monitor_activity_log_alert.app_service_delete](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_activity_log_alert) | resource |
 | [azurerm_monitor_activity_log_alert.app_service_stop](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_activity_log_alert) | resource |
-| [azurerm_monitor_diagnostic_setting.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_setting.web_app_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.app_service_http_5xx](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.app_service_response_time](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_private_endpoint.private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/private_endpoint) | resource |

--- a/app/modules/node-app-service/README.md
+++ b/app/modules/node-app-service/README.md
@@ -34,6 +34,7 @@ No modules.
 | [azurerm_linux_web_app_slot.staging](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/linux_web_app_slot) | resource |
 | [azurerm_monitor_activity_log_alert.app_service_delete](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_activity_log_alert) | resource |
 | [azurerm_monitor_activity_log_alert.app_service_stop](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_diagnostic_setting.example](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.app_service_http_5xx](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.app_service_response_time](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_private_endpoint.private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/private_endpoint) | resource |
@@ -45,8 +46,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority alerts | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The name of the app service | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_service_plan_resource_group_name"></a> [app\_service\_plan\_resource\_group\_name](#input\_app\_service\_plan\_resource\_group\_name) | The App Service Plan resource group name required for custom hostname certificate placement | `string` | `null` | no |
@@ -64,6 +63,7 @@ No modules.
 | <a name="input_integration_subnet_id"></a> [integration\_subnet\_id](#input\_integration\_subnet\_id) | The id of the vnet integration subnet the app service is linked to for egress traffic | `string` | `null` | no |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the key vault so the App Service can pull secret values | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The name of the app service location | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Azure Monitor Log Analytics Workspace | `string` | n/a | yes |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_outbound_vnet_connectivity"></a> [outbound\_vnet\_connectivity](#input\_outbound\_vnet\_connectivity) | Indicates whether outbound connectivity (VNET Integration) is required | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |

--- a/app/modules/node-app-service/locals.tf
+++ b/app/modules/node-app-service/locals.tf
@@ -1,13 +1,8 @@
 locals {
   app_settings = {
-    APPINSIGHTS_INSTRUMENTATIONKEY             = var.app_insights_instrumentation_key
-    APPLICATIONINSIGHTS_CONNECTION_STRING      = var.app_insights_connection_string
-    ApplicationInsightsAgent_EXTENSION_VERSION = "~3"
-    DOCKER_ENABLE_CI                           = true
-    DOCKER_REGISTRY_SERVER_PASSWORD            = sensitive(data.azurerm_container_registry.acr.admin_password)
-    DOCKER_REGISTRY_SERVER_URL                 = data.azurerm_container_registry.acr.login_server
-    DOCKER_REGISTRY_SERVER_USERNAME            = data.azurerm_container_registry.acr.admin_username
-    XDT_MicrosoftApplicationInsights_Mode      = "default"
-    XDT_MicrosoftApplicationInsights_NodeJS    = "1"
+    DOCKER_ENABLE_CI                = true
+    DOCKER_REGISTRY_SERVER_PASSWORD = sensitive(data.azurerm_container_registry.acr.admin_password)
+    DOCKER_REGISTRY_SERVER_URL      = data.azurerm_container_registry.acr.login_server
+    DOCKER_REGISTRY_SERVER_USERNAME = data.azurerm_container_registry.acr.admin_username
   }
 }

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -180,25 +180,16 @@ resource "azurerm_key_vault_access_policy" "read_secrets" {
   storage_permissions     = []
 }
 
-resource "azurerm_monitor_diagnostic_setting" "example" {
+resource "azurerm_monitor_diagnostic_setting" "web_app_logs" {
   name                       = "AppServiceLogs"
   log_analytics_workspace_id = var.log_analytics_workspace_id
   target_resource_id         = azurerm_linux_web_app.web_app.id
 
   log {
     category = "AppServiceConsoleLogs"
-    enabled  = true
-
-    retention_policy {
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = false
-    }
   }
 }

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -179,3 +179,26 @@ resource "azurerm_key_vault_access_policy" "read_secrets" {
   secret_permissions      = ["Get"]
   storage_permissions     = []
 }
+
+resource "azurerm_monitor_diagnostic_setting" "example" {
+  name                       = "AppServiceLogs"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+  target_resource_id         = azurerm_linux_web_app.web_app.id
+
+  log {
+    category = "AppServiceConsoleLogs"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -179,17 +179,3 @@ resource "azurerm_key_vault_access_policy" "read_secrets" {
   secret_permissions      = ["Get"]
   storage_permissions     = []
 }
-
-resource "azurerm_monitor_diagnostic_setting" "web_app_logs" {
-  name                       = "AppServiceLogs"
-  log_analytics_workspace_id = var.log_analytics_workspace_id
-  target_resource_id         = azurerm_linux_web_app.web_app.id
-
-  log {
-    category = "AppServiceConsoleLogs"
-  }
-
-  metric {
-    category = "AllMetrics"
-  }
-}

--- a/app/modules/node-app-service/monitoring.tf
+++ b/app/modules/node-app-service/monitoring.tf
@@ -1,3 +1,17 @@
+resource "azurerm_monitor_diagnostic_setting" "web_app_logs" {
+  name                       = "AppServiceLogs"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+  target_resource_id         = azurerm_linux_web_app.web_app.id
+
+  log {
+    category = "AppServiceConsoleLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+  }
+}
+
 resource "azurerm_monitor_metric_alert" "app_service_http_5xx" {
   name                = "Http 5xx - ${reverse(split("/", azurerm_linux_web_app.web_app.id))[0]}"
   resource_group_name = var.resource_group_name

--- a/app/modules/node-app-service/monitoring.tf
+++ b/app/modules/node-app-service/monitoring.tf
@@ -10,6 +10,13 @@ resource "azurerm_monitor_diagnostic_setting" "web_app_logs" {
   metric {
     category = "AllMetrics"
   }
+
+  lifecycle {
+    ignore_changes = [
+      log,
+      metric
+    ]
+  }
 }
 
 resource "azurerm_monitor_metric_alert" "app_service_http_5xx" {

--- a/app/modules/node-app-service/variables.tf
+++ b/app/modules/node-app-service/variables.tf
@@ -3,18 +3,6 @@ variable "action_group_low_id" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_name" {
   description = "The name of the app service"
   type        = string
@@ -103,6 +91,11 @@ variable "integration_subnet_id" {
 
 variable "location" {
   description = "The name of the app service location"
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Azure Monitor Log Analytics Workspace"
   type        = string
 }
 

--- a/app/modules/node-function-app/README.md
+++ b/app/modules/node-function-app/README.md
@@ -32,8 +32,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority alerts | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The name of the function app | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | The environment variables to be passed to the application | `map(string)` | `{}` | no |

--- a/app/modules/node-function-app/README.md
+++ b/app/modules/node-function-app/README.md
@@ -24,6 +24,7 @@ No modules.
 | [azurerm_linux_function_app.function_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) | resource |
 | [azurerm_monitor_activity_log_alert.function_app_delete](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
 | [azurerm_monitor_activity_log_alert.function_app_stop](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_diagnostic_setting.function_app_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.function_app_http_5xx](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.function_app_response_time](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 
@@ -39,6 +40,7 @@ No modules.
 | <a name="input_function_apps_storage_account"></a> [function\_apps\_storage\_account](#input\_function\_apps\_storage\_account) | The name of the storage account used by the Function Apps | `string` | n/a | yes |
 | <a name="input_function_apps_storage_account_access_key"></a> [function\_apps\_storage\_account\_access\_key](#input\_function\_apps\_storage\_account\_access\_key) | The access key for the storage account | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The name of the app service location | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Azure Monitor Log Analytics Workspace | `string` | n/a | yes |
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix for resource naming | `string` | n/a | yes |

--- a/app/modules/node-function-app/main.tf
+++ b/app/modules/node-function-app/main.tf
@@ -24,10 +24,8 @@ resource "azurerm_linux_function_app" "function_app" {
   }
 
   site_config {
-    always_on                              = true
-    application_insights_connection_string = var.app_insights_connection_string
-    application_insights_key               = var.app_insights_instrumentation_key
-    http2_enabled                          = true
+    always_on     = true
+    http2_enabled = true
 
     application_stack {
       node_version = 14

--- a/app/modules/node-function-app/monitoring.tf
+++ b/app/modules/node-function-app/monitoring.tf
@@ -10,6 +10,13 @@ resource "azurerm_monitor_diagnostic_setting" "function_app_logs" {
   metric {
     category = "AllMetrics"
   }
+
+  lifecycle {
+    ignore_changes = [
+      log,
+      metric
+    ]
+  }
 }
 
 resource "azurerm_monitor_metric_alert" "function_app_http_5xx" {

--- a/app/modules/node-function-app/monitoring.tf
+++ b/app/modules/node-function-app/monitoring.tf
@@ -1,3 +1,17 @@
+resource "azurerm_monitor_diagnostic_setting" "function_app_logs" {
+  name                       = "Function App Logs"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+  target_resource_id         = azurerm_linux_function_app.function_app.id
+
+  log {
+    category = "FunctionAppLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+  }
+}
+
 resource "azurerm_monitor_metric_alert" "function_app_http_5xx" {
   name                = "Http 5xx - ${reverse(split("/", azurerm_linux_function_app.function_app.id))[0]}"
   resource_group_name = var.resource_group_name

--- a/app/modules/node-function-app/variables.tf
+++ b/app/modules/node-function-app/variables.tf
@@ -3,18 +3,6 @@ variable "action_group_low_id" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_name" {
   description = "The name of the function app"
   type        = string

--- a/app/modules/node-function-app/variables.tf
+++ b/app/modules/node-function-app/variables.tf
@@ -41,6 +41,11 @@ variable "location" {
   type        = string
 }
 
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Azure Monitor Log Analytics Workspace"
+  type        = string
+}
+
 variable "monitoring_alerts_enabled" {
   default     = false
   description = "Indicates whether Azure Monitor alerts are enabled for App Service"

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -25,6 +25,7 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -25,7 +25,6 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -25,6 +25,7 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
@@ -37,8 +38,6 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_appeal_documents_primary_blob_connection_string"></a> [appeal\_documents\_primary\_blob\_connection\_string](#input\_appeal\_documents\_primary\_blob\_connection\_string) | The Appeal Documents Storage Account blob connection string associated with the primary location | `string` | n/a | yes |
 | <a name="input_appeal_documents_storage_container_name"></a> [appeal\_documents\_storage\_container\_name](#input\_appeal\_documents\_storage\_container\_name) | The name of the Storage Container for Appeal Documents | `string` | n/a | yes |

--- a/app/stacks/uk-south/appeals-service/app-service.tf
+++ b/app/stacks/uk-south/appeals-service/app-service.tf
@@ -5,8 +5,6 @@ module "app_services" {
 
   action_group_low_id                                                         = var.action_group_low_id
   api_timeout                                                                 = var.api_timeout
-  app_insights_connection_string                                              = var.app_insights_connection_string
-  app_insights_instrumentation_key                                            = var.app_insights_instrumentation_key
   app_service_plan_id                                                         = var.app_service_plan_id
   app_service_private_dns_zone_id                                             = data.azurerm_private_dns_zone.app_service.id
   appeal_documents_primary_blob_connection_string                             = var.appeal_documents_primary_blob_connection_string
@@ -25,6 +23,7 @@ module "app_services" {
   key_vault_id                                                                = var.key_vault_id
   key_vault_uri                                                               = var.key_vault_uri
   location                                                                    = azurerm_resource_group.appeals_service_stack.location
+  log_analytics_workspace_id                                                  = azurerm_log_analytics_workspace.appeals_service.id
   logger_level                                                                = var.logger_level
   monitoring_alerts_enabled                                                   = var.monitoring_alerts_enabled
   node_environment                                                            = var.node_environment

--- a/app/stacks/uk-south/appeals-service/monitoring.tf
+++ b/app/stacks/uk-south/appeals-service/monitoring.tf
@@ -7,3 +7,12 @@ resource "azurerm_log_analytics_workspace" "appeals_service" {
 
   tags = local.tags
 }
+
+resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
+  name                       = "App Service Console Logs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.appeals_service.id
+
+  category     = "App Logs"
+  display_name = "App Service Console Logs"
+  query        = "AppServiceConsoleLogs"
+}

--- a/app/stacks/uk-south/appeals-service/monitoring.tf
+++ b/app/stacks/uk-south/appeals-service/monitoring.tf
@@ -1,0 +1,9 @@
+resource "azurerm_log_analytics_workspace" "appeals_service" {
+  name                = "pins-log-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.appeals_service_stack.name
+  location            = azurerm_resource_group.appeals_service_stack.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = local.tags
+}

--- a/app/stacks/uk-south/appeals-service/monitoring.tf
+++ b/app/stacks/uk-south/appeals-service/monitoring.tf
@@ -7,12 +7,3 @@ resource "azurerm_log_analytics_workspace" "appeals_service" {
 
   tags = local.tags
 }
-
-resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
-  name                       = "App Service Console Logs"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.appeals_service.id
-
-  category     = "App Logs"
-  display_name = "App Service Console Logs"
-  query        = "AppServiceConsoleLogs"
-}

--- a/app/stacks/uk-south/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-south/appeals-service/terragrunt.hcl
@@ -23,10 +23,8 @@ dependency "common_uks" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    app_insights_connection_string   = "mock_connection_string"
-    app_insights_instrumentation_key = "mock_instrumentation_key"
-    app_service_plan_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
-    common_resource_group_name       = "mock_resource_group_name"
+    app_service_plan_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
+    common_resource_group_name = "mock_resource_group_name"
     common_vnet_cidr_blocks = {
       app_service_integration   = "10.1.1.0/24"
       appeals_service_endpoints = "10.1.2.0/24"
@@ -53,8 +51,6 @@ dependency "common_ukw" {
 
 inputs = {
   action_group_low_id                             = dependency.common_ukw.outputs.action_group_low_id
-  app_insights_connection_string                  = try(dependency.common_uks.outputs.app_insights_connection_string, null)
-  app_insights_instrumentation_key                = try(dependency.common_uks.outputs.app_insights_instrumentation_key, null)
   app_service_plan_id                             = try(dependency.common_uks.outputs.app_service_plan_id, null)
   appeal_documents_primary_blob_connection_string = dependency.appeals_service_ukw.outputs.appeal_documents_primary_blob_connection_string
   appeal_documents_storage_container_name         = dependency.appeals_service_ukw.outputs.appeal_documents_storage_container_name

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -8,18 +8,6 @@ variable "api_timeout" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
   type        = string

--- a/app/stacks/uk-south/applications-service/README.md
+++ b/app/stacks/uk-south/applications-service/README.md
@@ -26,6 +26,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
+| [azurerm_log_analytics_workspace.applcations_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network_gateway_connection.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway_connection) | resource |
@@ -37,8 +38,6 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_applications_service_public_url"></a> [applications\_service\_public\_url](#input\_applications\_service\_public\_url) | The public URL for the Applications Service frontend web app | `string` | n/a | yes |
 | <a name="input_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#input\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key | `string` | n/a | yes |

--- a/app/stacks/uk-south/applications-service/README.md
+++ b/app/stacks/uk-south/applications-service/README.md
@@ -26,7 +26,6 @@ No requirements.
 | Name | Type |
 |------|------|
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
-| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.applcations_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |

--- a/app/stacks/uk-south/applications-service/README.md
+++ b/app/stacks/uk-south/applications-service/README.md
@@ -26,6 +26,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
+| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.applcations_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |

--- a/app/stacks/uk-south/applications-service/app-service.tf
+++ b/app/stacks/uk-south/applications-service/app-service.tf
@@ -5,8 +5,6 @@ module "app_services" {
 
   action_group_low_id                                             = var.action_group_low_id
   api_timeout                                                     = var.api_timeout
-  app_insights_connection_string                                  = var.app_insights_connection_string
-  app_insights_instrumentation_key                                = var.app_insights_instrumentation_key
   app_service_plan_id                                             = var.app_service_plan_id
   app_service_private_dns_zone_id                                 = data.azurerm_private_dns_zone.app_service.id
   applications_service_public_url                                 = var.applications_service_public_url
@@ -18,6 +16,7 @@ module "app_services" {
   key_vault_id                                                    = var.key_vault_id
   key_vault_uri                                                   = var.key_vault_uri
   location                                                        = azurerm_resource_group.applications_service_stack.location
+  log_analytics_workspace_id                                      = azurerm_log_analytics_workspace.applcations_service.id
   logger_level                                                    = var.logger_level
   monitoring_alerts_enabled                                       = var.monitoring_alerts_enabled
   node_environment                                                = var.node_environment

--- a/app/stacks/uk-south/applications-service/monitoring.tf
+++ b/app/stacks/uk-south/applications-service/monitoring.tf
@@ -7,12 +7,3 @@ resource "azurerm_log_analytics_workspace" "applcations_service" {
 
   tags = local.tags
 }
-
-resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
-  name                       = "App Service Console Logs"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.applcations_service.id
-
-  category     = "App Logs"
-  display_name = "App Service Console Logs"
-  query        = "AppServiceConsoleLogs"
-}

--- a/app/stacks/uk-south/applications-service/monitoring.tf
+++ b/app/stacks/uk-south/applications-service/monitoring.tf
@@ -7,3 +7,12 @@ resource "azurerm_log_analytics_workspace" "applcations_service" {
 
   tags = local.tags
 }
+
+resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
+  name                       = "App Service Console Logs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.applcations_service.id
+
+  category     = "App Logs"
+  display_name = "App Service Console Logs"
+  query        = "AppServiceConsoleLogs"
+}

--- a/app/stacks/uk-south/applications-service/monitoring.tf
+++ b/app/stacks/uk-south/applications-service/monitoring.tf
@@ -1,0 +1,9 @@
+resource "azurerm_log_analytics_workspace" "applcations_service" {
+  name                = "pins-log-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  location            = azurerm_resource_group.applications_service_stack.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = local.tags
+}

--- a/app/stacks/uk-south/applications-service/terragrunt.hcl
+++ b/app/stacks/uk-south/applications-service/terragrunt.hcl
@@ -8,8 +8,6 @@ dependency "common_uks" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    app_insights_connection_string              = "mock_connection_string"
-    app_insights_instrumentation_key            = "mock_instrumentation_key"
     app_service_plan_id                         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
     applications_service_vpn_gateway_shared_key = "mock_shared_key"
     common_resource_group_name                  = "mock_resource_group_name"
@@ -36,8 +34,6 @@ dependency "common_ukw" {
 
 inputs = {
   action_group_low_id                         = dependency.common_ukw.outputs.action_group_low_id
-  app_insights_connection_string              = try(dependency.common_uks.outputs.app_insights_connection_string, null)
-  app_insights_instrumentation_key            = try(dependency.common_uks.outputs.app_insights_instrumentation_key, null)
   app_service_plan_id                         = try(dependency.common_uks.outputs.app_service_plan_id, null)
   applications_service_vpn_gateway_shared_key = dependency.common_uks.outputs.applications_service_vpn_gateway_shared_key
   common_resource_group_name                  = dependency.common_uks.outputs.common_resource_group_name

--- a/app/stacks/uk-south/applications-service/variables.tf
+++ b/app/stacks/uk-south/applications-service/variables.tf
@@ -8,18 +8,6 @@ variable "api_timeout" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "applications_service_vpn_gateway_shared_key" {
   description = "The applications service virtual network gateway shared key"
   sensitive   = true

--- a/app/stacks/uk-south/back-office/README.md
+++ b/app/stacks/uk-south/back-office/README.md
@@ -25,6 +25,7 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_failover_group.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_failover_group) | resource |
 | [azurerm_mssql_server.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server) | resource |

--- a/app/stacks/uk-south/back-office/README.md
+++ b/app/stacks/uk-south/back-office/README.md
@@ -25,7 +25,6 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_failover_group.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_failover_group) | resource |
 | [azurerm_mssql_server.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server) | resource |

--- a/app/stacks/uk-south/back-office/README.md
+++ b/app/stacks/uk-south/back-office/README.md
@@ -25,6 +25,7 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [azurerm_log_analytics_workspace.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_failover_group.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_failover_group) | resource |
 | [azurerm_mssql_server.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server) | resource |
 | [azurerm_private_endpoint.back_office_sql_server](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
@@ -39,8 +40,6 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_azuread_auth_case_officer_group_id"></a> [azuread\_auth\_case\_officer\_group\_id](#input\_azuread\_auth\_case\_officer\_group\_id) | The Azure AD group ID for Back Office case officers | `string` | `null` | no |
 | <a name="input_azuread_auth_client_id"></a> [azuread\_auth\_client\_id](#input\_azuread\_auth\_client\_id) | The Back Office web frontend app registration ID used for Azure AD authentication | `string` | `null` | no |

--- a/app/stacks/uk-south/back-office/app-service.tf
+++ b/app/stacks/uk-south/back-office/app-service.tf
@@ -4,8 +4,6 @@ module "app_services" {
   source = "../../../components/back-office-app-services"
 
   action_group_low_id                     = var.action_group_low_id
-  app_insights_connection_string          = var.app_insights_connection_string
-  app_insights_instrumentation_key        = var.app_insights_instrumentation_key
   app_service_plan_id                     = var.app_service_plan_id
   app_service_plan_resource_group_name    = var.common_resource_group_name
   app_service_private_dns_zone_id         = data.azurerm_private_dns_zone.app_service.id
@@ -23,6 +21,7 @@ module "app_services" {
   key_vault_id                            = var.key_vault_id
   key_vault_uri                           = var.key_vault_uri
   location                                = azurerm_resource_group.back_office_stack.location
+  log_analytics_workspace_id              = azurerm_log_analytics_workspace.back_office.id
   monitoring_alerts_enabled               = var.monitoring_alerts_enabled
   node_environment                        = var.node_environment
   private_endpoint_enabled                = var.private_endpoint_enabled

--- a/app/stacks/uk-south/back-office/monitoring.tf
+++ b/app/stacks/uk-south/back-office/monitoring.tf
@@ -7,12 +7,3 @@ resource "azurerm_log_analytics_workspace" "back_office" {
 
   tags = local.tags
 }
-
-resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
-  name                       = "App Service Console Logs"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.back_office.id
-
-  category     = "App Logs"
-  display_name = "App Service Console Logs"
-  query        = "AppServiceConsoleLogs"
-}

--- a/app/stacks/uk-south/back-office/monitoring.tf
+++ b/app/stacks/uk-south/back-office/monitoring.tf
@@ -12,7 +12,7 @@ resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
   name                       = "App Service Console Logs"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.back_office.id
 
-  category     = "Applications"
+  category     = "App Logs"
   display_name = "App Service Console Logs"
   query        = "AppServiceConsoleLogs"
 }

--- a/app/stacks/uk-south/back-office/monitoring.tf
+++ b/app/stacks/uk-south/back-office/monitoring.tf
@@ -1,0 +1,9 @@
+resource "azurerm_log_analytics_workspace" "back_office" {
+  name                = "pins-log-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.back_office_stack.name
+  location            = azurerm_resource_group.back_office_stack.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = local.tags
+}

--- a/app/stacks/uk-south/back-office/monitoring.tf
+++ b/app/stacks/uk-south/back-office/monitoring.tf
@@ -7,3 +7,12 @@ resource "azurerm_log_analytics_workspace" "back_office" {
 
   tags = local.tags
 }
+
+resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
+  name                       = "App Service Console Logs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.back_office.id
+
+  category     = "Applications"
+  display_name = "App Service Console Logs"
+  query        = "AppServiceConsoleLogs"
+}

--- a/app/stacks/uk-south/back-office/terragrunt.hcl
+++ b/app/stacks/uk-south/back-office/terragrunt.hcl
@@ -8,10 +8,8 @@ dependency "common_uks" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    app_insights_connection_string   = "mock_connection_string"
-    app_insights_instrumentation_key = "mock_instrumentation_key"
-    app_service_plan_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
-    common_resource_group_name       = "mock_resource_group_name"
+    app_service_plan_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
+    common_resource_group_name = "mock_resource_group_name"
     common_vnet_cidr_blocks = {
       back_office_endpoints = "10.1.4.0/24"
     }
@@ -46,18 +44,16 @@ dependency "back_office_ukw" {
 }
 
 inputs = {
-  action_group_low_id              = dependency.common_ukw.outputs.action_group_low_id
-  app_insights_connection_string   = try(dependency.common_uks.outputs.app_insights_connection_string, null)
-  app_insights_instrumentation_key = try(dependency.common_uks.outputs.app_insights_instrumentation_key, null)
-  app_service_plan_id              = try(dependency.common_uks.outputs.app_service_plan_id, null)
-  back_office_sql_database         = dependency.back_office_ukw.outputs.back_office_sql_database
-  common_resource_group_name       = dependency.common_uks.outputs.common_resource_group_name
-  common_vnet_cidr_blocks          = dependency.common_uks.outputs.common_vnet_cidr_blocks
-  common_vnet_name                 = dependency.common_uks.outputs.common_vnet_name
-  integration_subnet_id            = dependency.common_uks.outputs.integration_subnet_id
-  key_vault_id                     = dependency.common_ukw.outputs.key_vault_id
-  key_vault_uri                    = dependency.common_ukw.outputs.key_vault_uri
-  primary_sql_server_id            = dependency.back_office_ukw.outputs.sql_server_id
-  sql_server_password              = dependency.back_office_ukw.outputs.sql_server_password
-  sql_server_username              = dependency.back_office_ukw.outputs.sql_server_username
+  action_group_low_id        = dependency.common_ukw.outputs.action_group_low_id
+  app_service_plan_id        = try(dependency.common_uks.outputs.app_service_plan_id, null)
+  back_office_sql_database   = dependency.back_office_ukw.outputs.back_office_sql_database
+  common_resource_group_name = dependency.common_uks.outputs.common_resource_group_name
+  common_vnet_cidr_blocks    = dependency.common_uks.outputs.common_vnet_cidr_blocks
+  common_vnet_name           = dependency.common_uks.outputs.common_vnet_name
+  integration_subnet_id      = dependency.common_uks.outputs.integration_subnet_id
+  key_vault_id               = dependency.common_ukw.outputs.key_vault_id
+  key_vault_uri              = dependency.common_ukw.outputs.key_vault_uri
+  primary_sql_server_id      = dependency.back_office_ukw.outputs.sql_server_id
+  sql_server_password        = dependency.back_office_ukw.outputs.sql_server_password
+  sql_server_username        = dependency.back_office_ukw.outputs.sql_server_username
 }

--- a/app/stacks/uk-south/back-office/variables.tf
+++ b/app/stacks/uk-south/back-office/variables.tf
@@ -3,18 +3,6 @@ variable "action_group_low_id" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
   type        = string

--- a/app/stacks/uk-south/common/README.md
+++ b/app/stacks/uk-south/common/README.md
@@ -24,7 +24,6 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azurerm_application_insights.node](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_resource_group.common_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_service_plan.common_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
 
@@ -48,8 +47,6 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
-| <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
 | <a name="output_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#output\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key |
 | <a name="output_common_resource_group_name"></a> [common\_resource\_group\_name](#output\_common\_resource\_group\_name) | The name of the common infrastructure resource group |

--- a/app/stacks/uk-south/common/application-insights.tf
+++ b/app/stacks/uk-south/common/application-insights.tf
@@ -1,9 +1,0 @@
-resource "azurerm_application_insights" "node" {
-  count = var.is_dr_deployment ? 1 : 0
-
-  name                = "pins-appi-${local.service_name}-node-${local.resource_suffix}"
-  resource_group_name = azurerm_resource_group.common_infrastructure.name
-  location            = azurerm_resource_group.common_infrastructure.location
-  application_type    = "Node.JS"
-  tags                = local.tags
-}

--- a/app/stacks/uk-south/common/outputs.tf
+++ b/app/stacks/uk-south/common/outputs.tf
@@ -1,15 +1,3 @@
-output "app_insights_connection_string" {
-  description = "The Application Insights connection string used to allow monitoring on App Services"
-  sensitive   = true
-  value       = length(azurerm_application_insights.node) > 0 ? azurerm_application_insights.node[0].connection_string : null
-}
-
-output "app_insights_instrumentation_key" {
-  description = "The Application Insights instrumentation key used to allow monitoring on App Services"
-  sensitive   = true
-  value       = length(azurerm_application_insights.node) > 0 ? azurerm_application_insights.node[0].instrumentation_key : null
-}
-
 output "app_service_plan_id" {
   description = "The id of the app service plan"
   value       = length(azurerm_service_plan.common_service_plan) > 0 ? azurerm_service_plan.common_service_plan[0].id : null

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -29,6 +29,7 @@ No requirements.
 | [azurerm_advanced_threat_protection.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/advanced_threat_protection) | resource |
 | [azurerm_cosmosdb_account.appeals_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_account.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
@@ -44,8 +45,6 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_appeals_service_public_url"></a> [appeals\_service\_public\_url](#input\_appeals\_service\_public\_url) | The public URL for the Appeals Service frontend web app | `string` | n/a | yes |
 | <a name="input_common_resource_group_name"></a> [common\_resource\_group\_name](#input\_common\_resource\_group\_name) | The common infrastructure resource group name | `string` | n/a | yes |

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -29,7 +29,6 @@ No requirements.
 | [azurerm_advanced_threat_protection.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/advanced_threat_protection) | resource |
 | [azurerm_cosmosdb_account.appeals_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -29,6 +29,7 @@ No requirements.
 | [azurerm_advanced_threat_protection.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/advanced_threat_protection) | resource |
 | [azurerm_cosmosdb_account.appeals_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/app/stacks/uk-west/appeals-service/app-service.tf
+++ b/app/stacks/uk-west/appeals-service/app-service.tf
@@ -3,8 +3,6 @@ module "app_services" {
 
   action_group_low_id                                                         = var.action_group_low_id
   api_timeout                                                                 = var.api_timeout
-  app_insights_connection_string                                              = var.app_insights_connection_string
-  app_insights_instrumentation_key                                            = var.app_insights_instrumentation_key
   app_service_plan_id                                                         = var.app_service_plan_id
   app_service_private_dns_zone_id                                             = data.azurerm_private_dns_zone.app_service.id
   appeal_documents_primary_blob_connection_string                             = azurerm_storage_account.appeal_documents.primary_blob_connection_string
@@ -23,6 +21,7 @@ module "app_services" {
   key_vault_id                                                                = var.key_vault_id
   key_vault_uri                                                               = var.key_vault_uri
   location                                                                    = module.azure_region_primary.location
+  log_analytics_workspace_id                                                  = azurerm_log_analytics_workspace.appeals_service.id
   logger_level                                                                = var.logger_level
   monitoring_alerts_enabled                                                   = var.monitoring_alerts_enabled
   node_environment                                                            = var.node_environment

--- a/app/stacks/uk-west/appeals-service/monitoring.tf
+++ b/app/stacks/uk-west/appeals-service/monitoring.tf
@@ -7,3 +7,12 @@ resource "azurerm_log_analytics_workspace" "appeals_service" {
 
   tags = local.tags
 }
+
+resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
+  name                       = "App Service Console Logs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.appeals_service.id
+
+  category     = "App Logs"
+  display_name = "App Service Console Logs"
+  query        = "AppServiceConsoleLogs"
+}

--- a/app/stacks/uk-west/appeals-service/monitoring.tf
+++ b/app/stacks/uk-west/appeals-service/monitoring.tf
@@ -1,0 +1,9 @@
+resource "azurerm_log_analytics_workspace" "appeals_service" {
+  name                = "pins-log-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.appeals_service_stack.name
+  location            = azurerm_resource_group.appeals_service_stack.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = local.tags
+}

--- a/app/stacks/uk-west/appeals-service/monitoring.tf
+++ b/app/stacks/uk-west/appeals-service/monitoring.tf
@@ -7,12 +7,3 @@ resource "azurerm_log_analytics_workspace" "appeals_service" {
 
   tags = local.tags
 }
-
-resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
-  name                       = "App Service Console Logs"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.appeals_service.id
-
-  category     = "App Logs"
-  display_name = "App Service Console Logs"
-  query        = "AppServiceConsoleLogs"
-}

--- a/app/stacks/uk-west/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-west/appeals-service/terragrunt.hcl
@@ -8,11 +8,9 @@ dependency "common_ukw" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    action_group_low_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
-    app_insights_connection_string   = "mock_connection_string"
-    app_insights_instrumentation_key = "mock_instrumentation_key"
-    app_service_plan_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
-    common_resource_group_name       = "mock_resource_group_name"
+    action_group_low_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
+    app_service_plan_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
+    common_resource_group_name = "mock_resource_group_name"
     common_vnet_cidr_blocks = {
       app_service_integration   = "10.1.1.0/24"
       appeals_service_endpoints = "10.1.2.0/24"
@@ -27,15 +25,13 @@ dependency "common_ukw" {
 }
 
 inputs = {
-  action_group_low_id              = dependency.common_ukw.outputs.action_group_low_id
-  app_insights_connection_string   = dependency.common_ukw.outputs.app_insights_connection_string
-  app_insights_instrumentation_key = dependency.common_ukw.outputs.app_insights_instrumentation_key
-  app_service_plan_id              = dependency.common_ukw.outputs.app_service_plan_id
-  common_resource_group_name       = dependency.common_ukw.outputs.common_resource_group_name
-  common_vnet_cidr_blocks          = dependency.common_ukw.outputs.common_vnet_cidr_blocks
-  common_vnet_name                 = dependency.common_ukw.outputs.common_vnet_name
-  cosmosdb_subnet_id               = try(dependency.common_ukw.outputs.cosmosdb_subnet_id, null)
-  integration_subnet_id            = dependency.common_ukw.outputs.integration_subnet_id
-  key_vault_id                     = dependency.common_ukw.outputs.key_vault_id
-  key_vault_uri                    = dependency.common_ukw.outputs.key_vault_uri
+  action_group_low_id        = dependency.common_ukw.outputs.action_group_low_id
+  app_service_plan_id        = dependency.common_ukw.outputs.app_service_plan_id
+  common_resource_group_name = dependency.common_ukw.outputs.common_resource_group_name
+  common_vnet_cidr_blocks    = dependency.common_ukw.outputs.common_vnet_cidr_blocks
+  common_vnet_name           = dependency.common_ukw.outputs.common_vnet_name
+  cosmosdb_subnet_id         = try(dependency.common_ukw.outputs.cosmosdb_subnet_id, null)
+  integration_subnet_id      = dependency.common_ukw.outputs.integration_subnet_id
+  key_vault_id               = dependency.common_ukw.outputs.key_vault_id
+  key_vault_uri              = dependency.common_ukw.outputs.key_vault_uri
 }

--- a/app/stacks/uk-west/appeals-service/variables.tf
+++ b/app/stacks/uk-west/appeals-service/variables.tf
@@ -8,18 +8,6 @@ variable "api_timeout" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
   type        = string

--- a/app/stacks/uk-west/applications-service/README.md
+++ b/app/stacks/uk-west/applications-service/README.md
@@ -27,6 +27,7 @@ No requirements.
 |------|------|
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
+| [azurerm_log_analytics_workspace.applications_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_virtual_network_gateway_connection.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_gateway_connection) | resource |
@@ -38,8 +39,6 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_applications_service_public_url"></a> [applications\_service\_public\_url](#input\_applications\_service\_public\_url) | The public URL for the Applications Service frontend web app | `string` | n/a | yes |
 | <a name="input_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#input\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key | `string` | n/a | yes |

--- a/app/stacks/uk-west/applications-service/README.md
+++ b/app/stacks/uk-west/applications-service/README.md
@@ -27,7 +27,6 @@ No requirements.
 |------|------|
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
-| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.applications_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |

--- a/app/stacks/uk-west/applications-service/README.md
+++ b/app/stacks/uk-west/applications-service/README.md
@@ -27,6 +27,7 @@ No requirements.
 |------|------|
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/local_network_gateway) | resource |
+| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.applications_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.applications_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.applications_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |

--- a/app/stacks/uk-west/applications-service/app-service.tf
+++ b/app/stacks/uk-west/applications-service/app-service.tf
@@ -3,8 +3,6 @@ module "app_services" {
 
   action_group_low_id                                             = var.action_group_low_id
   api_timeout                                                     = var.api_timeout
-  app_insights_connection_string                                  = var.app_insights_connection_string
-  app_insights_instrumentation_key                                = var.app_insights_instrumentation_key
   app_service_plan_id                                             = var.app_service_plan_id
   app_service_private_dns_zone_id                                 = data.azurerm_private_dns_zone.app_service.id
   applications_service_public_url                                 = var.applications_service_public_url
@@ -17,6 +15,7 @@ module "app_services" {
   key_vault_uri                                                   = var.key_vault_uri
   location                                                        = azurerm_resource_group.applications_service_stack.location
   monitoring_alerts_enabled                                       = var.monitoring_alerts_enabled
+  log_analytics_workspace_id                                      = azurerm_log_analytics_workspace.applications_service.id
   logger_level                                                    = var.logger_level
   node_environment                                                = var.node_environment
   private_endpoint_enabled                                        = var.private_endpoint_enabled

--- a/app/stacks/uk-west/applications-service/monitoring.tf
+++ b/app/stacks/uk-west/applications-service/monitoring.tf
@@ -7,12 +7,3 @@ resource "azurerm_log_analytics_workspace" "applications_service" {
 
   tags = local.tags
 }
-
-resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
-  name                       = "App Service Console Logs"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.applications_service.id
-
-  category     = "App Logs"
-  display_name = "App Service Console Logs"
-  query        = "AppServiceConsoleLogs"
-}

--- a/app/stacks/uk-west/applications-service/monitoring.tf
+++ b/app/stacks/uk-west/applications-service/monitoring.tf
@@ -7,3 +7,12 @@ resource "azurerm_log_analytics_workspace" "applications_service" {
 
   tags = local.tags
 }
+
+resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
+  name                       = "App Service Console Logs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.applications_service.id
+
+  category     = "App Logs"
+  display_name = "App Service Console Logs"
+  query        = "AppServiceConsoleLogs"
+}

--- a/app/stacks/uk-west/applications-service/monitoring.tf
+++ b/app/stacks/uk-west/applications-service/monitoring.tf
@@ -1,0 +1,9 @@
+resource "azurerm_log_analytics_workspace" "applications_service" {
+  name                = "pins-log-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  location            = azurerm_resource_group.applications_service_stack.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = local.tags
+}

--- a/app/stacks/uk-west/applications-service/terragrunt.hcl
+++ b/app/stacks/uk-west/applications-service/terragrunt.hcl
@@ -9,8 +9,6 @@ dependency "common" {
 
   mock_outputs = {
     action_group_low_id                         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
-    app_insights_connection_string              = "mock_connection_string"
-    app_insights_instrumentation_key            = "mock_instrumentation_key"
     app_service_plan_id                         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
     applications_service_vpn_gateway_shared_key = "mock_shared_key"
     common_resource_group_name                  = "mock_resource_group_name"
@@ -29,8 +27,6 @@ dependency "common" {
 
 inputs = {
   action_group_low_id                         = dependency.common.outputs.action_group_low_id
-  app_insights_connection_string              = dependency.common.outputs.app_insights_connection_string
-  app_insights_instrumentation_key            = dependency.common.outputs.app_insights_instrumentation_key
   app_service_plan_id                         = dependency.common.outputs.app_service_plan_id
   applications_service_vpn_gateway_shared_key = dependency.common.outputs.applications_service_vpn_gateway_shared_key
   common_resource_group_name                  = dependency.common.outputs.common_resource_group_name

--- a/app/stacks/uk-west/applications-service/variables.tf
+++ b/app/stacks/uk-west/applications-service/variables.tf
@@ -8,18 +8,6 @@ variable "api_timeout" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "applications_service_vpn_gateway_shared_key" {
   description = "The applications service virtual network gateway shared key"
   sensitive   = true

--- a/app/stacks/uk-west/back-office/README.md
+++ b/app/stacks/uk-west/back-office/README.md
@@ -50,8 +50,6 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
-| <a name="input_app_insights_connection_string"></a> [app\_insights\_connection\_string](#input\_app\_insights\_connection\_string) | The connection string to connect to an Application Insights resource | `string` | n/a | yes |
-| <a name="input_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#input\_app\_insights\_instrumentation\_key) | The instrumentation key to connect to an Application Insights resource | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_azuread_auth_case_officer_group_id"></a> [azuread\_auth\_case\_officer\_group\_id](#input\_azuread\_auth\_case\_officer\_group\_id) | The Azure AD group ID for Back Office case officers | `string` | `null` | no |
 | <a name="input_azuread_auth_client_id"></a> [azuread\_auth\_client\_id](#input\_azuread\_auth\_client\_id) | The Back Office web frontend app registration ID used for Azure AD authentication | `string` | `null` | no |

--- a/app/stacks/uk-west/back-office/README.md
+++ b/app/stacks/uk-west/back-office/README.md
@@ -30,7 +30,6 @@ No requirements.
 | [azurerm_key_vault_secret.back_office_sql_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.back_office_sql_server_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.back_office_sql_server_username](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_diagnostic_setting.back_office_sql_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_mssql_database.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) | resource |

--- a/app/stacks/uk-west/back-office/README.md
+++ b/app/stacks/uk-west/back-office/README.md
@@ -30,6 +30,7 @@ No requirements.
 | [azurerm_key_vault_secret.back_office_sql_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.back_office_sql_server_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.back_office_sql_server_username](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_log_analytics_saved_search.app_service_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_diagnostic_setting.back_office_sql_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_mssql_database.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) | resource |

--- a/app/stacks/uk-west/back-office/app-service.tf
+++ b/app/stacks/uk-west/back-office/app-service.tf
@@ -2,8 +2,6 @@ module "app_services" {
   source = "../../../components/back-office-app-services"
 
   action_group_low_id                     = var.action_group_low_id
-  app_insights_connection_string          = var.app_insights_connection_string
-  app_insights_instrumentation_key        = var.app_insights_instrumentation_key
   app_service_plan_id                     = var.app_service_plan_id
   app_service_plan_resource_group_name    = var.common_resource_group_name
   app_service_private_dns_zone_id         = data.azurerm_private_dns_zone.app_service.id
@@ -21,6 +19,7 @@ module "app_services" {
   key_vault_id                            = var.key_vault_id
   key_vault_uri                           = var.key_vault_uri
   location                                = azurerm_resource_group.back_office_stack.location
+  log_analytics_workspace_id              = azurerm_log_analytics_workspace.back_office.id
   monitoring_alerts_enabled               = var.monitoring_alerts_enabled
   node_environment                        = var.node_environment
   private_endpoint_enabled                = var.private_endpoint_enabled

--- a/app/stacks/uk-west/back-office/monitoring.tf
+++ b/app/stacks/uk-west/back-office/monitoring.tf
@@ -8,15 +8,6 @@ resource "azurerm_log_analytics_workspace" "back_office" {
   tags = local.tags
 }
 
-resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
-  name                       = "App Service Console Logs"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.back_office.id
-
-  category     = "App Logs"
-  display_name = "App Service Console Logs"
-  query        = "AppServiceConsoleLogs"
-}
-
 resource "azurerm_monitor_diagnostic_setting" "back_office_sql_database" {
   name                       = "SQLDatabaseAudit"
   target_resource_id         = azurerm_mssql_database.back_office.id

--- a/app/stacks/uk-west/back-office/monitoring.tf
+++ b/app/stacks/uk-west/back-office/monitoring.tf
@@ -8,6 +8,15 @@ resource "azurerm_log_analytics_workspace" "back_office" {
   tags = local.tags
 }
 
+resource "azurerm_log_analytics_saved_search" "app_service_console_logs" {
+  name                       = "App Service Console Logs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.back_office.id
+
+  category     = "App Logs"
+  display_name = "App Service Console Logs"
+  query        = "AppServiceConsoleLogs"
+}
+
 resource "azurerm_monitor_diagnostic_setting" "back_office_sql_database" {
   name                       = "SQLDatabaseAudit"
   target_resource_id         = azurerm_mssql_database.back_office.id

--- a/app/stacks/uk-west/back-office/terragrunt.hcl
+++ b/app/stacks/uk-west/back-office/terragrunt.hcl
@@ -8,11 +8,9 @@ dependency "common" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    action_group_low_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
-    app_insights_connection_string   = "mock_connection_string"
-    app_insights_instrumentation_key = "mock_instrumentation_key"
-    app_service_plan_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
-    common_resource_group_name       = "mock_resource_group_name"
+    action_group_low_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/microsoft.insights/actionGroups/mock"
+    app_service_plan_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.Web/serverfarms/mock_id"
+    common_resource_group_name = "mock_resource_group_name"
     common_vnet_cidr_blocks = {
       back_office_endpoints = "10.1.4.0/24"
     }
@@ -24,15 +22,13 @@ dependency "common" {
 }
 
 inputs = {
-  action_group_low_id              = dependency.common.outputs.action_group_low_id
-  app_insights_connection_string   = dependency.common.outputs.app_insights_connection_string
-  app_insights_instrumentation_key = dependency.common.outputs.app_insights_instrumentation_key
-  app_service_plan_id              = dependency.common.outputs.app_service_plan_id
-  common_resource_group_name       = dependency.common.outputs.common_resource_group_name
-  common_vnet_cidr_blocks          = dependency.common.outputs.common_vnet_cidr_blocks
-  common_vnet_gateway_id           = dependency.common.outputs.common_vnet_gateway_id
-  common_vnet_name                 = dependency.common.outputs.common_vnet_name
-  integration_subnet_id            = dependency.common.outputs.integration_subnet_id
-  key_vault_uri                    = dependency.common.outputs.key_vault_uri
-  key_vault_id                     = dependency.common.outputs.key_vault_id
+  action_group_low_id        = dependency.common.outputs.action_group_low_id
+  app_service_plan_id        = dependency.common.outputs.app_service_plan_id
+  common_resource_group_name = dependency.common.outputs.common_resource_group_name
+  common_vnet_cidr_blocks    = dependency.common.outputs.common_vnet_cidr_blocks
+  common_vnet_gateway_id     = dependency.common.outputs.common_vnet_gateway_id
+  common_vnet_name           = dependency.common.outputs.common_vnet_name
+  integration_subnet_id      = dependency.common.outputs.integration_subnet_id
+  key_vault_uri              = dependency.common.outputs.key_vault_uri
+  key_vault_id               = dependency.common.outputs.key_vault_id
 }

--- a/app/stacks/uk-west/back-office/variables.tf
+++ b/app/stacks/uk-west/back-office/variables.tf
@@ -3,18 +3,6 @@ variable "action_group_low_id" {
   type        = string
 }
 
-variable "app_insights_connection_string" {
-  description = "The connection string to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
-variable "app_insights_instrumentation_key" {
-  description = "The instrumentation key to connect to an Application Insights resource"
-  sensitive   = true
-  type        = string
-}
-
 variable "app_service_plan_id" {
   description = "The id of the app service plan"
   type        = string

--- a/app/stacks/uk-west/common/README.md
+++ b/app/stacks/uk-west/common/README.md
@@ -24,7 +24,6 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azurerm_application_insights.node](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_key_vault.environment_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_access_policy.admins](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.app_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -60,8 +59,6 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | <a name="output_action_group_low_id"></a> [action\_group\_low\_id](#output\_action\_group\_low\_id) | The Action Group ID for sending low priority (P4) alerts |
-| <a name="output_app_insights_connection_string"></a> [app\_insights\_connection\_string](#output\_app\_insights\_connection\_string) | The Application Insights connection string used to allow monitoring on App Services |
-| <a name="output_app_insights_instrumentation_key"></a> [app\_insights\_instrumentation\_key](#output\_app\_insights\_instrumentation\_key) | The Application Insights instrumentation key used to allow monitoring on App Services |
 | <a name="output_app_service_plan_id"></a> [app\_service\_plan\_id](#output\_app\_service\_plan\_id) | The id of the app service plan |
 | <a name="output_applications_service_vpn_gateway_shared_key"></a> [applications\_service\_vpn\_gateway\_shared\_key](#output\_applications\_service\_vpn\_gateway\_shared\_key) | The applications service virtual network gateway shared key |
 | <a name="output_common_resource_group_name"></a> [common\_resource\_group\_name](#output\_common\_resource\_group\_name) | The name of the common infrastructure resource group |

--- a/app/stacks/uk-west/common/application-insights.tf
+++ b/app/stacks/uk-west/common/application-insights.tf
@@ -1,7 +1,0 @@
-resource "azurerm_application_insights" "node" {
-  name                = "pins-appi-${local.service_name}-node-${local.resource_suffix}"
-  resource_group_name = azurerm_resource_group.common_infrastructure.name
-  location            = azurerm_resource_group.common_infrastructure.location
-  application_type    = "Node.JS"
-  tags                = local.tags
-}

--- a/app/stacks/uk-west/common/outputs.tf
+++ b/app/stacks/uk-west/common/outputs.tf
@@ -3,18 +3,6 @@ output "action_group_low_id" {
   value       = azurerm_monitor_action_group.low.id
 }
 
-output "app_insights_connection_string" {
-  description = "The Application Insights connection string used to allow monitoring on App Services"
-  sensitive   = true
-  value       = azurerm_application_insights.node.connection_string
-}
-
-output "app_insights_instrumentation_key" {
-  description = "The Application Insights instrumentation key used to allow monitoring on App Services"
-  sensitive   = true
-  value       = azurerm_application_insights.node.instrumentation_key
-}
-
 output "app_service_plan_id" {
   description = "The id of the app service plan"
   value       = azurerm_service_plan.common_service_plan.id


### PR DESCRIPTION
- Add diagnostic settings to App Services and Function App to send logs to Azure Monitor
- Add a log analytics workspace in all required stacks
- Remove all Application Insights resources as these are now replaced with Azure Monitor

Main changes are in the `monitoring.tf` files, and the `node-app-service` and `node-function-app` modules.