### PR TITLE
Fix Horizon publisher environment variable

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -15,7 +15,7 @@ This module also contains some resources such as Service Bus and Function Apps r
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.6.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.0.2 |
 
 ## Modules
 

--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -15,7 +15,7 @@ This module also contains some resources such as Service Bus and Function Apps r
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.0.2 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.6.0 |
 
 ## Modules
 

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -64,7 +64,7 @@ locals {
         FEATURE_FLAG_NEW_APPEAL_JOURNEY                                       = true
         HORIZON_HAS_PUBLISHER_ATTEMPT_RECONNECTION                            = true
         HORIZON_HAS_PUBLISHER_HOST                                            = "${azurerm_servicebus_namespace.horizon.name}.servicebus.windows.net"
-        HORIZON_HAS_PUBLISHER_PASSWORD                                        = split("SharedAccessKey=", azurerm_servicebus_namespace_authorization_rule.horizon_function_apps.primary_connection_string)[1]
+        HORIZON_HAS_PUBLISHER_PASSWORD                                        = azurerm_servicebus_namespace_authorization_rule.horizon_function_apps.primary_key
         HORIZON_HAS_PUBLISHER_PORT                                            = "5671"
         HORIZON_HAS_PUBLISHER_QUEUE                                           = azurerm_servicebus_queue.horizon_householder_appeal_publish.name
         HORIZON_HAS_PUBLISHER_RECONNECT_LIMIT                                 = "5"

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -64,7 +64,7 @@ locals {
         FEATURE_FLAG_NEW_APPEAL_JOURNEY                                       = true
         HORIZON_HAS_PUBLISHER_ATTEMPT_RECONNECTION                            = true
         HORIZON_HAS_PUBLISHER_HOST                                            = "${azurerm_servicebus_namespace.horizon.name}.servicebus.windows.net"
-        HORIZON_HAS_PUBLISHER_PASSWORD                                        = azurerm_servicebus_namespace_authorization_rule.horizon_function_apps.primary_connection_string
+        HORIZON_HAS_PUBLISHER_PASSWORD                                        = split("SharedAccessKey=", azurerm_servicebus_namespace_authorization_rule.horizon_function_apps.primary_connection_string)[1]
         HORIZON_HAS_PUBLISHER_PORT                                            = "5671"
         HORIZON_HAS_PUBLISHER_QUEUE                                           = azurerm_servicebus_queue.horizon_householder_appeal_publish.name
         HORIZON_HAS_PUBLISHER_RECONNECT_LIMIT                                 = "5"


### PR DESCRIPTION
- Split the Horizon service bus connection string to pass in only the shared access key to the `HORIZON_HAS_PUBLISHER_PASSWORD` environment variable.