### PR TITLE
Separate App Registration per environment for Back Office auth

### DIFF
--- a/app/modules/node-app-service/README.md
+++ b/app/modules/node-app-service/README.md
@@ -29,6 +29,7 @@ No modules.
 | [azurerm_app_service_slot_virtual_network_swift_connection.vnet_connection](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/app_service_slot_virtual_network_swift_connection) | resource |
 | [azurerm_app_service_virtual_network_swift_connection.vnet_connection](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/app_service_virtual_network_swift_connection) | resource |
 | [azurerm_key_vault_access_policy.read_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.read_secrets_staging_slot](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_linux_web_app.web_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/linux_web_app) | resource |
 | [azurerm_linux_web_app_slot.staging](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/linux_web_app_slot) | resource |
 | [azurerm_monitor_activity_log_alert.app_service_delete](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/monitor_activity_log_alert) | resource |

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -170,3 +170,16 @@ resource "azurerm_key_vault_access_policy" "read_secrets" {
   secret_permissions      = ["Get"]
   storage_permissions     = []
 }
+
+resource "azurerm_key_vault_access_policy" "read_secrets_staging_slot" {
+  count = var.key_vault_id != null ? 1 : 0
+
+  key_vault_id = var.key_vault_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_linux_web_app_slot.staging.identity.0.principal_id
+
+  certificate_permissions = []
+  key_permissions         = []
+  secret_permissions      = ["Get"]
+  storage_permissions     = []
+}

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -154,7 +154,7 @@ resource "azurerm_app_service_slot_virtual_network_swift_connection" "vnet_conne
   count = var.outbound_vnet_connectivity ? 1 : 0
 
   app_service_id = azurerm_linux_web_app.web_app.id
-  slot_name      = "staging"
+  slot_name      = azurerm_linux_web_app_slot.staging.name
   subnet_id      = var.integration_subnet_id
 }
 

--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -1,6 +1,6 @@
 locals {
   azuread_auth_case_officer_group_id      = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_auth_client_id                  = "2dc22997-3900-4602-b3bd-46385b60e2b2"
+  azuread_auth_client_id                  = "7cab8971-c305-4b9a-82db-21b5fd84efbd"
   azuread_auth_inspector_group_id         = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
   azuread_auth_validation_office_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
   node_environment                        = "production"

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -1,6 +1,6 @@
 locals {
   azuread_auth_case_officer_group_id      = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_auth_client_id                  = "2dc22997-3900-4602-b3bd-46385b60e2b2"
+  azuread_auth_client_id                  = "dff02ad8-1efc-4f5f-8b1c-58a93edd14f1"
   azuread_auth_inspector_group_id         = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
   azuread_auth_validation_office_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
   node_environment                        = "production"

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -42,7 +42,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.1
+      ref: refs/tags/release/2.5.5
 
 extends:
   template: stages/wrapper_cd.yml@templates

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -83,7 +83,6 @@ extends:
       - name: Terraform Apply
         ${{ if eq(parameters.stack, 'all') }}:
           artifact: terraform-config-files
-        condition: and(succeeded(), ne(variables['skipApply'], 'true'))
         dependsOn:
           - Terraform Plan
         deploymentSteps:
@@ -105,5 +104,3 @@ extends:
               parameters:
                 artifactName: terraform-plan-$(ENVIRONMENT)
                 subscriptionId: $(SUBSCRIPTION_ID)
-        variables:
-          skipApply: $[stageDependencies.Terraform_Plan.Terraform_Plan.outputs['terraform_plan.skipApply']]

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.1
+      ref: refs/tags/release/2.5.5
 
 extends:
   template: stages/wrapper_ci.yml@templates


### PR DESCRIPTION
- Use a separate App Registration per environment for the Back Office Authentication
- Fixes a dependency issue in the App Service module where the VNet integration was not provisioned in the correct order
- Allow staging slots ability to read from Key Vault
- Update pipeline to remove skipApply as this is now done in the templates