### PR TITLE
Remove staging slot settings and use values from production slot

### DIFF
--- a/app/modules/node-app-service/locals.tf
+++ b/app/modules/node-app-service/locals.tf
@@ -8,16 +8,4 @@ locals {
       DOCKER_REGISTRY_SERVER_USERNAME = data.azurerm_container_registry.acr.admin_username
     }
   )
-
-  # Since some App Settings will be URLs to other Azure App Services, this local variable parses each one and does the following:
-  # 1. Check if the setting contains an App Service URL. We do this by looking for the '<resource_suffix.azurewebsites.net' string
-  # 2. Remove '.azurewebsites.net' string from the end of the URL
-  # 3. Truncate the string to 48 characters (this is the number of characters including https:// that Azure use before adding the staging slot in the URL)
-  # 4. If the last character after truncation is a '-' remove this too
-  # 5. Add "-staging.azurewebsites.net" back at the end of the string to complete the URL
-  # 6. Add a '/' character back at the end if the original App Setting included this
-  # The final result will be a URL of a staging slot
-  staging_slot_app_settings = {
-    for k, v in local.app_settings : k => length(regexall("${var.resource_suffix}\\.azurewebsites\\.net\\/?$", v)) > 0 ? length(regexall("\\/$", v)) > 0 ? "${trimsuffix(substr(replace(v, ".azurewebsites.net/", ""), 0, 48), "-")}-staging.azurewebsites.net/" : "${trimsuffix(substr(replace(v, ".azurewebsites.net", ""), 0, 48), "-")}-staging.azurewebsites.net" : v
-  }
 }

--- a/app/modules/node-app-service/main.tf
+++ b/app/modules/node-app-service/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_linux_web_app_slot" "staging" {
   client_certificate_enabled = false
   https_only                 = true
 
-  app_settings = local.staging_slot_app_settings
+  app_settings = local.app_settings
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Removing the hack to make staging slots point at other staging slots. Reason for this is that when you do the slot swap, it also swaps the values of the app settings.