### PR TITLE
Add WAF exclusion for applicant website

### DIFF
--- a/app/stacks/global/front-door/waf-policy.tf
+++ b/app/stacks/global/front-door/waf-policy.tf
@@ -10,6 +10,23 @@ resource "azurerm_frontdoor_firewall_policy" "default" {
     version = "1.0"
 
     override {
+      rule_group_name = "RFI"
+
+      rule {
+        # Possible Remote File Inclusion (RFI) Attack: Off-Domain Reference/Link
+        rule_id = "931130"
+        action  = "Block"
+
+        exclusion {
+          # Exclusion to fix BOAS-153
+          match_variable = "RequestBodyPostArgNames" # PostParamValue:applicant.website
+          operator       = "Equals"
+          selector       = "applicant.website"
+        }
+      }
+    }
+
+    override {
       rule_group_name = "SQLI"
 
       rule {


### PR DESCRIPTION
- Add a web application firewall rule exclusion for the RFI ruleset which was preventing request body posts for applicant website.
- Successfully deployed and tested in the dev environment to fix BOAS-153.