### PR TITLE
chore(applications-app-service): add path env var

### DIFF
--- a/app/components/applications-app-services/README.md
+++ b/app/components/applications-app-services/README.md
@@ -37,6 +37,9 @@ No resources.
 | <a name="input_container_registry_rg"></a> [container\_registry\_rg](#input\_container\_registry\_rg) | The resource group of the container registry that hosts the image | `string` | n/a | yes |
 | <a name="input_documents_host"></a> [documents\_host](#input\_documents\_host) | Specifies environment specific Wordpress CMS URL Prefix | `string` | n/a | yes |
 | <a name="input_endpoint_subnet_id"></a> [endpoint\_subnet\_id](#input\_endpoint\_subnet\_id) | The id of the private endpoint subnet the app service is linked to for ingress traffic | `string` | n/a | yes |
+| <a name="input_feature_allow_document_library"></a> [feature\_allow\_document\_library](#input\_feature\_allow\_document\_library) | Feature toggle for limiting the web app routes to document library | `string` | n/a | yes |
+| <a name="input_feature_allow_representation"></a> [feature\_allow\_representation](#input\_feature\_allow\_representation) | Feature toggle for limiting the web app routes to representation | `string` | n/a | yes |
+| <a name="input_feature_hide_project_timeline_link"></a> [feature\_hide\_project\_timeline\_link](#input\_feature\_hide\_project\_timeline\_link) | Feature toggle to show / hide the project timeline link on project overview nav bar | `string` | n/a | yes |
 | <a name="input_feature_save_and_exit_option"></a> [feature\_save\_and\_exit\_option](#input\_feature\_save\_and\_exit\_option) | Feature toggle for showing the save and exit option on registration form | `string` | n/a | yes |
 | <a name="input_feature_show_affected_area_section"></a> [feature\_show\_affected\_area\_section](#input\_feature\_show\_affected\_area\_section) | Feature toggle for showing the affected area section on project page | `string` | n/a | yes |
 | <a name="input_google_analytics_id"></a> [google\_analytics\_id](#input\_google\_analytics\_id) | The id used to connect the frontend app to Google Analytics | `string` | n/a | yes |

--- a/app/components/applications-app-services/locals.tf
+++ b/app/components/applications-app-services/locals.tf
@@ -12,6 +12,7 @@ locals {
       app_settings = {
         APPLICATIONS_SERVICE_API_TIMEOUT   = var.api_timeout
         APPLICATIONS_SERVICE_API_URL       = "https://pins-app-${var.service_name}-applications-api-${var.resource_suffix}.azurewebsites.net/"
+        FILE_UPLOADS_PATH                  = "/opt/app/uploads"
         GOOGLE_ANALYTICS_ID                = var.google_analytics_id
         HOST_URL                           = "https://${var.applications_service_public_url}/"
         SESSION_KEY                        = local.secret_refs["applications-service-session-key"]


### PR DESCRIPTION
- Adds `FILE_UPLOADS_PATH` environment variable for the Applications App Service container, which defines the path the app should use as temporary storage for uploading files