### PR TITLE
App Service private access to App Configuration and Key Vault

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -29,6 +29,7 @@ This module also contains some resources such as Service Bus and Function Apps r
 
 | Name | Type |
 |------|------|
+| [azurerm_role_assignment.app_configuration_access](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.documents_access](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/role_assignment) | resource |
 | [azurerm_servicebus_namespace.horizon](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/servicebus_namespace) | resource |
 | [azurerm_servicebus_namespace_authorization_rule.horizon_function_apps](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/servicebus_namespace_authorization_rule) | resource |

--- a/app/components/appeals-app-services/iam.tf
+++ b/app/components/appeals-app-services/iam.tf
@@ -3,3 +3,9 @@ resource "azurerm_role_assignment" "documents_access" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = module.app_service["appeal_documents_service_api"].principal_id
 }
+
+resource "azurerm_role_assignment" "app_configuration_access" {
+  scope                = var.resource_group_id
+  role_definition_name = "App Configuration Data Reader"
+  principal_id         = module.app_service["appeal_documents_service_api"].principal_id
+}

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -104,7 +104,7 @@ locals {
       image_name                      = "appeal-planning-decision/documents-api"
       inbound_vnet_connectivity       = var.private_endpoint_enabled
       integration_subnet_id           = var.integration_subnet_id
-      key_vault_access                = false
+      key_vault_access                = true
       outbound_vnet_connectivity      = true
 
       app_settings = {
@@ -132,7 +132,7 @@ locals {
       endpoint_subnet_id              = var.private_endpoint_enabled ? var.endpoint_subnet_id : null
       image_name                      = "appeal-planning-decision/pdf-api"
       inbound_vnet_connectivity       = var.private_endpoint_enabled
-      key_vault_access                = false
+      key_vault_access                = true
       outbound_vnet_connectivity      = false
 
       app_settings = {
@@ -153,7 +153,7 @@ locals {
       endpoint_subnet_id              = var.private_endpoint_enabled ? var.endpoint_subnet_id : null
       image_name                      = "appeal-planning-decision/clamav-api"
       inbound_vnet_connectivity       = var.private_endpoint_enabled
-      key_vault_access                = false
+      key_vault_access                = true
       outbound_vnet_connectivity      = false
 
       app_settings = {

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -140,7 +140,6 @@ locals {
         GOTENBERG_URL                           = "http://gotenberg:4000"
         LOGGER_LEVEL                            = var.logger_level
         NODE_ENV                                = var.node_environment
-        PINS_FEATURE_FLAG_AZURE_ENDPOINT        = local.secret_refs["appeals-app-config-endpoint"]
         SERVER_PORT                             = "3000"
         SERVER_SHOW_ERRORS                      = true
         SERVER_TERMINATION_GRACE_PERIOD_SECONDS = "0"
@@ -153,11 +152,11 @@ locals {
       endpoint_subnet_id              = var.private_endpoint_enabled ? var.endpoint_subnet_id : null
       image_name                      = "appeal-planning-decision/clamav-api"
       inbound_vnet_connectivity       = var.private_endpoint_enabled
-      key_vault_access                = true
+      key_vault_access                = false
       outbound_vnet_connectivity      = false
 
       app_settings = {
-        PINS_FEATURE_FLAG_AZURE_ENDPOINT = local.secret_refs["appeals-app-config-endpoint"]
+
       }
     }
   }

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -27,8 +27,10 @@ No requirements.
 |------|------|
 | [azurerm_app_configuration.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_private_endpoint.appeals_app_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_private_dns_zone.app_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.app_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 
 ## Inputs

--- a/app/stacks/uk-south/appeals-service/app-service-config.tf
+++ b/app/stacks/uk-south/appeals-service/app-service-config.tf
@@ -15,7 +15,7 @@ resource "azurerm_private_endpoint" "appeals_app_config" {
   name                = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
   location            = azurerm_resource_group.appeals_service_stack.location
   resource_group_name = azurerm_resource_group.appeals_service_stack.name
-  subnet_id           = var.integration_subnet_id
+  subnet_id           = azurerm_subnet.appeals_service_ingress.id
 
   private_dns_zone_group {
     name                 = "default"

--- a/app/stacks/uk-south/appeals-service/app-service-config.tf
+++ b/app/stacks/uk-south/appeals-service/app-service-config.tf
@@ -8,3 +8,26 @@ resource "azurerm_app_configuration" "appeals_service" {
 
   tags = local.tags
 }
+
+resource "azurerm_private_endpoint" "appeals_app_config" {
+  count = var.is_dr_deployment ? 1 : 0
+
+  name                = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
+  location            = azurerm_resource_group.appeals_service_stack.location
+  resource_group_name = azurerm_resource_group.appeals_service_stack.name
+  subnet_id           = var.integration_subnet_id
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.app_config.id]
+  }
+
+  private_service_connection {
+    name                           = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
+    private_connection_resource_id = azurerm_app_configuration.appeals_service[0].id
+    subresource_names              = ["configurationStores"]
+    is_manual_connection           = false
+  }
+
+  tags = local.tags
+}

--- a/app/stacks/uk-south/appeals-service/data.tf
+++ b/app/stacks/uk-south/appeals-service/data.tf
@@ -1,3 +1,9 @@
+data "azurerm_private_dns_zone" "app_config" {
+  name = "privatelink.azconfig.io"
+
+  provider = azurerm.tooling
+}
+
 data "azurerm_private_dns_zone" "app_service" {
   name = "privatelink.azurewebsites.net"
 

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -31,12 +31,14 @@ No requirements.
 | [azurerm_cosmosdb_account.appeals_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_key_vault_secret.app_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_private_endpoint.appeals_app_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_account.appeal_documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_account.function_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.documents](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_private_dns_zone.app_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.app_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 

--- a/app/stacks/uk-west/appeals-service/app-service-config.tf
+++ b/app/stacks/uk-west/appeals-service/app-service-config.tf
@@ -11,7 +11,7 @@ resource "azurerm_private_endpoint" "appeals_app_config" {
   name                = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
   location            = azurerm_resource_group.appeals_service_stack.location
   resource_group_name = azurerm_resource_group.appeals_service_stack.name
-  subnet_id           = var.integration_subnet_id
+  subnet_id           = azurerm_subnet.appeals_service_ingress.id
 
   private_dns_zone_group {
     name                 = "default"

--- a/app/stacks/uk-west/appeals-service/app-service-config.tf
+++ b/app/stacks/uk-west/appeals-service/app-service-config.tf
@@ -6,3 +6,24 @@ resource "azurerm_app_configuration" "appeals_service" {
 
   tags = local.tags
 }
+
+resource "azurerm_private_endpoint" "appeals_app_config" {
+  name                = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
+  location            = azurerm_resource_group.appeals_service_stack.location
+  resource_group_name = azurerm_resource_group.appeals_service_stack.name
+  subnet_id           = var.integration_subnet_id
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.app_config.id]
+  }
+
+  private_service_connection {
+    name                           = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
+    private_connection_resource_id = azurerm_app_configuration.appeals_service.id
+    subresource_names              = ["configurationStores"]
+    is_manual_connection           = false
+  }
+
+  tags = local.tags
+}

--- a/app/stacks/uk-west/appeals-service/data.tf
+++ b/app/stacks/uk-west/appeals-service/data.tf
@@ -1,3 +1,9 @@
+data "azurerm_private_dns_zone" "app_config" {
+  name = "privatelink.azconfig.io"
+
+  provider = azurerm.tooling
+}
+
 data "azurerm_private_dns_zone" "app_service" {
   name = "privatelink.azurewebsites.net"
 


### PR DESCRIPTION
- Grant RBAC permissions to the documents API for accessing App Configuration stores.
- Add a private endpoint for App Configuration stores to facilitate private access.