### PR TITLE
Conditional Service Bus SKU per environment

### DIFF
--- a/app/stacks/uk-south/back-office/README.md
+++ b/app/stacks/uk-south/back-office/README.md
@@ -72,6 +72,7 @@ No requirements.
 | <a name="input_primary_service_bus_namespace_id"></a> [primary\_service\_bus\_namespace\_id](#input\_primary\_service\_bus\_namespace\_id) | The ID of the primary Service Bus Namespace | `string` | n/a | yes |
 | <a name="input_primary_sql_server_id"></a> [primary\_sql\_server\_id](#input\_primary\_sql\_server\_id) | The ID of the primary Back Office SQL server | `string` | n/a | yes |
 | <a name="input_private_endpoint_enabled"></a> [private\_endpoint\_enabled](#input\_private\_endpoint\_enabled) | A switch to determine if Private Endpoint should be enabled for backend App Services | `bool` | `true` | no |
+| <a name="input_service_bus_failover_enabled"></a> [service\_bus\_failover\_enabled](#input\_service\_bus\_failover\_enabled) | A switch to determine if Service Bus failover is enabled requiring the Premium SKU | `bool` | `false` | no |
 | <a name="input_sql_server_azuread_administrator"></a> [sql\_server\_azuread\_administrator](#input\_sql\_server\_azuread\_administrator) | A map describing the AzureAD account used for the SQL server administrator | `map(string)` | n/a | yes |
 | <a name="input_sql_server_password"></a> [sql\_server\_password](#input\_sql\_server\_password) | The SQL server administrator password | `string` | n/a | yes |
 | <a name="input_sql_server_username"></a> [sql\_server\_username](#input\_sql\_server\_username) | The SQL server administrator username | `string` | n/a | yes |

--- a/app/stacks/uk-south/back-office/app-service.tf
+++ b/app/stacks/uk-south/back-office/app-service.tf
@@ -31,7 +31,7 @@ module "app_services" {
   private_endpoint_enabled                         = var.private_endpoint_enabled
   resource_group_name                              = azurerm_resource_group.back_office_stack.name
   resource_suffix                                  = local.resource_suffix
-  service_bus_namespace_name                       = azurerm_servicebus_namespace.back_office.name
+  service_bus_namespace_name                       = azurerm_servicebus_namespace.back_office[0].name
   service_name                                     = local.service_name
 
   tags = local.tags

--- a/app/stacks/uk-south/back-office/service-bus.tf
+++ b/app/stacks/uk-south/back-office/service-bus.tf
@@ -1,4 +1,6 @@
 resource "azurerm_servicebus_namespace" "back_office" {
+  count = var.service_bus_failover_enabled || var.is_dr_deployment ? 1 : 0
+
   name                = "pins-sb-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.back_office_stack.location
   resource_group_name = azurerm_resource_group.back_office_stack.name
@@ -13,5 +15,5 @@ resource "azurerm_servicebus_namespace_disaster_recovery_config" "back_office" {
 
   name                 = "pins-sb-dr-${local.service_name}-${local.resource_suffix}"
   primary_namespace_id = var.primary_service_bus_namespace_id
-  partner_namespace_id = azurerm_servicebus_namespace.back_office.id
+  partner_namespace_id = azurerm_servicebus_namespace.back_office[0].id
 }

--- a/app/stacks/uk-south/back-office/service-bus.tf
+++ b/app/stacks/uk-south/back-office/service-bus.tf
@@ -2,13 +2,15 @@ resource "azurerm_servicebus_namespace" "back_office" {
   name                = "pins-sb-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.back_office_stack.location
   resource_group_name = azurerm_resource_group.back_office_stack.name
-  sku                 = "Premium"
-  capacity            = 1
+  sku                 = var.service_bus_failover_enabled ? "Premium" : "Standard"
+  capacity            = var.service_bus_failover_enabled ? 1 : 0
 
   tags = local.tags
 }
 
 resource "azurerm_servicebus_namespace_disaster_recovery_config" "back_office" {
+  count = var.service_bus_failover_enabled ? 1 : 0
+
   name                 = "pins-sb-dr-${local.service_name}-${local.resource_suffix}"
   primary_namespace_id = var.primary_service_bus_namespace_id
   partner_namespace_id = azurerm_servicebus_namespace.back_office.id

--- a/app/stacks/uk-south/back-office/variables.tf
+++ b/app/stacks/uk-south/back-office/variables.tf
@@ -167,6 +167,12 @@ variable "primary_sql_server_id" {
   type        = string
 }
 
+variable "service_bus_failover_enabled" {
+  default     = false
+  description = "A switch to determine if Service Bus failover is enabled requiring the Premium SKU"
+  type        = bool
+}
+
 variable "sql_server_azuread_administrator" {
   description = "A map describing the AzureAD account used for the SQL server administrator"
   type        = map(string)

--- a/app/stacks/uk-west/back-office/README.md
+++ b/app/stacks/uk-west/back-office/README.md
@@ -80,6 +80,7 @@ No requirements.
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
 | <a name="input_private_endpoint_enabled"></a> [private\_endpoint\_enabled](#input\_private\_endpoint\_enabled) | A switch to determine if Private Endpoint should be enabled for backend App Services | `bool` | `true` | no |
+| <a name="input_service_bus_failover_enabled"></a> [service\_bus\_failover\_enabled](#input\_service\_bus\_failover\_enabled) | A switch to determine if Service Bus failover is enabled requiring the Premium SKU | `bool` | `false` | no |
 | <a name="input_sql_database_configuration"></a> [sql\_database\_configuration](#input\_sql\_database\_configuration) | A map of database configuration options | `map(string)` | n/a | yes |
 | <a name="input_sql_server_azuread_administrator"></a> [sql\_server\_azuread\_administrator](#input\_sql\_server\_azuread\_administrator) | A map describing the AzureAD account used for the SQL server administrator | `map(string)` | n/a | yes |
 

--- a/app/stacks/uk-west/back-office/service-bus.tf
+++ b/app/stacks/uk-west/back-office/service-bus.tf
@@ -2,8 +2,8 @@ resource "azurerm_servicebus_namespace" "back_office" {
   name                = "pins-sb-${local.service_name}-${local.resource_suffix}"
   location            = azurerm_resource_group.back_office_stack.location
   resource_group_name = azurerm_resource_group.back_office_stack.name
-  sku                 = "Premium"
-  capacity            = 1
+  sku                 = var.service_bus_failover_enabled ? "Premium" : "Standard"
+  capacity            = var.service_bus_failover_enabled ? 1 : 0
 
   tags = local.tags
 }

--- a/app/stacks/uk-west/back-office/variables.tf
+++ b/app/stacks/uk-west/back-office/variables.tf
@@ -141,6 +141,12 @@ variable "private_endpoint_enabled" {
   default     = true
 }
 
+variable "service_bus_failover_enabled" {
+  default     = false
+  description = "A switch to determine if Service Bus failover is enabled requiring the Premium SKU"
+  type        = bool
+}
+
 variable "sql_database_configuration" {
   description = "A map of database configuration options"
   type        = map(string)

--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -7,6 +7,7 @@ locals {
   azuread_applications_case_admin_officer_group_id = "b8bb03d5-9162-4f35-9ff3-856be16dff23"
   azuread_applications_caseofficer_group_id        = "ac136ed4-241a-459e-9b4e-267939fd4f08"
   azuread_applications_inspector_group_id          = "9dbf4271-7823-45ed-b1a7-3712f6f2faa3"
+  service_bus_failover_enabled                     = false
   sql_database_configuration = {
     max_size_gb               = 2
     short_term_retention_days = 7 # 7-35

--- a/config/variables/stacks/back-office/prod.hcl
+++ b/config/variables/stacks/back-office/prod.hcl
@@ -7,6 +7,7 @@ locals {
   azuread_applications_case_admin_officer_group_id = "b8bb03d5-9162-4f35-9ff3-856be16dff23"
   azuread_applications_caseofficer_group_id        = "ac136ed4-241a-459e-9b4e-267939fd4f08"
   azuread_applications_inspector_group_id          = "9dbf4271-7823-45ed-b1a7-3712f6f2faa3"
+  service_bus_failover_enabled                     = true
   sql_database_configuration = {
     max_size_gb               = 1024
     short_term_retention_days = 30 # 7-35

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -7,6 +7,7 @@ locals {
   azuread_applications_case_admin_officer_group_id = "b8bb03d5-9162-4f35-9ff3-856be16dff23"
   azuread_applications_caseofficer_group_id        = "ac136ed4-241a-459e-9b4e-267939fd4f08"
   azuread_applications_inspector_group_id          = "9dbf4271-7823-45ed-b1a7-3712f6f2faa3"
+  service_bus_failover_enabled                     = false
   sql_database_configuration = {
     max_size_gb               = 1024
     short_term_retention_days = 7 # 7-35


### PR DESCRIPTION
- Sets the default Service Bus SKU to `Standard` to save costs. Retains the `Premium` SKU for production to support high-availability and disaster recovery scenarios.