### PR TITLE
Failover deployment fixes

### DIFF
--- a/app/stacks/uk-south/applications-service/vpn-gateway.tf
+++ b/app/stacks/uk-south/applications-service/vpn-gateway.tf
@@ -2,7 +2,7 @@ resource "azurerm_local_network_gateway" "national_infrastructure" {
   count = var.is_dr_deployment ? 1 : 0
 
   name                = "pins-lgw-${local.service_name}-${local.resource_suffix}"
-  resource_group_name = azurerm_resource_group.applications_service_stack.name
+  resource_group_name = var.common_resource_group_name
   location            = azurerm_resource_group.applications_service_stack.location
   gateway_address     = var.national_infrastructure_gateway_ip
   address_space       = var.national_infrastructure_vnet_address_space
@@ -13,7 +13,7 @@ resource "azurerm_virtual_network_gateway_connection" "national_infrastructure" 
   count = var.is_dr_deployment ? 1 : 0
 
   name                       = "pins-vcn-${local.service_name}-${local.resource_suffix}"
-  resource_group_name        = azurerm_resource_group.applications_service_stack.name
+  resource_group_name        = var.common_resource_group_name
   location                   = azurerm_resource_group.applications_service_stack.location
   type                       = "IPsec"
   virtual_network_gateway_id = var.common_vnet_gateway_id

--- a/app/stacks/uk-south/back-office/terragrunt.hcl
+++ b/app/stacks/uk-south/back-office/terragrunt.hcl
@@ -37,7 +37,7 @@ dependency "back_office_ukw" {
 
   mock_outputs = {
     back_office_document_storage_api_host       = "https://mockstorageaccount.blob.core.windows.net/"
-    back_office_document_storage_documents_id   = "123"
+    back_office_document_storage_documents_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Storage/storageAccounts/mockstorageaccount"
     back_office_sql_database                    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Sql/servers/mock_sql_server/databases/mock_sql_db"
     back_office_document_storage_container_name = "mock-name"
     service_bus_namespace_id                    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.ServiceBus/namespaces/mock_sb_namespace"


### PR DESCRIPTION
- Move the VPN gateway resources to the common resource group.
- Fix mock value for storage account ID.