### PR TITLE
chore(applications): default document library feature flag on

### DIFF
--- a/config/variables/stacks/applications-service/prod.hcl
+++ b/config/variables/stacks/applications-service/prod.hcl
@@ -11,7 +11,7 @@ locals {
   feature_save_and_exit_option                                    = "false"
   feature_show_affected_area_section                              = "false"
   feature_hide_project_timeline_link                              = "false"
-  feature_allow_document_library                                  = "false"
+  feature_allow_document_library                                  = "true"
   feature_allow_representation                                    = "true"
   documents_host                                                  = "https://infrastructure.planninginspectorate.gov.uk/wp-content/ipc/uploads/projects/"
 }


### PR DESCRIPTION
Default Applications document library functionality to be on as it is now active in production.