### PR TITLE
feat(applications-service): add filter to applications-nsip-project subscription

### DIFF
--- a/app/components/applications-app-services/README.md
+++ b/app/components/applications-app-services/README.md
@@ -29,6 +29,7 @@ This module contains the App Services resources for the applications service. Th
 |------|------|
 | [azurerm_role_assignment.nsip_service_bus_role](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/role_assignment) | resource |
 | [azurerm_servicebus_subscription.nsip_project_topic_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/servicebus_subscription) | resource |
+| [azurerm_servicebus_subscription_rule.nsip_project_topic_subscription_rule](https://registry.terraform.io/providers/hashicorp/azurerm/3.6.0/docs/resources/servicebus_subscription_rule) | resource |
 
 ## Inputs
 

--- a/app/components/applications-app-services/function-app.tf
+++ b/app/components/applications-app-services/function-app.tf
@@ -35,6 +35,19 @@ resource "azurerm_servicebus_subscription" "nsip_project_topic_subscription" {
   max_delivery_count = 1
 }
 
+resource "azurerm_servicebus_subscription_rule" "nsip_project_topic_subscription_rule" {
+  count = var.feature_back_office_subscriber_enabled ? 1 : 0
+
+  name            = "applications-nsip-project-subscription-rule"
+  subscription_id = azurerm_servicebus_subscription.nsip_project_topic_subscription[0].id
+  filter_type     = "CorrelationFilter"
+  correlation_filter {
+    properties = {
+      type = "Publish"
+    }
+  }
+}
+
 resource "azurerm_role_assignment" "nsip_service_bus_role" {
   count = var.feature_back_office_subscriber_enabled ? 1 : 0
 


### PR DESCRIPTION
- adds filter to the `applications-nsip-project-subscription` so that we only receive messages with `type` of `Publish` from Back Office Service Bus