### PR TITLE
fix(applications-service): set secure cookie true

### DIFF
--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -40,7 +40,7 @@ locals {
         SESSION_MONGODB_DB_NAME                    = "forms-web-app"
         SESSION_MONGODB_URL                        = var.cosmosdb_connection_string
         SUBDOMAIN_OFFSET                           = "3"
-        USE_SECURE_SESSION_COOKIES                 = false
+        USE_SECURE_SESSION_COOKIES                 = true
       }
     }
 


### PR DESCRIPTION
set 'USE_SECURE_SESSION_COOKIES' to true

Setting to true will partially address the concerns in: [[AS-5886] - PINS Jira (atlassian.net)](https://pins-ds.atlassian.net/browse/AS-5886)

Will also tangentially fix: [[AS-5898] - PINS Jira (atlassian.net)](https://pins-ds.atlassian.net/browse/AS-5898) as trust proxy setting is driven off this and will pick up the domain/subdomain from azure front door