### PR TITLE
feat(appeals-service): add env variable ALLOW_TESTING_OVERRIDES

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -40,6 +40,7 @@ This module also contains some resources such as Service Bus and Function Apps r
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority alerts | `string` | n/a | yes |
+| <a name="input_allow_testing_overrides"></a> [allow\_testing\_overrides](#input\_allow\_testing\_overrides) | A switch to determine if testing overrides are enabled to allow easier manual testing | `bool` | `false` | no |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_app_service_private_dns_zone_id"></a> [app\_service\_private\_dns\_zone\_id](#input\_app\_service\_private\_dns\_zone\_id) | The id of the private DNS zone for App services | `string` | n/a | yes |

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -41,6 +41,7 @@ locals {
         SESSION_MONGODB_URL                        = var.cosmosdb_connection_string
         SUBDOMAIN_OFFSET                           = "3"
         USE_SECURE_SESSION_COOKIES                 = true
+        ALLOW_TESTING_OVERRIDES                    = var.allow_testing_overrides
       }
     }
 

--- a/app/components/appeals-app-services/variables.tf
+++ b/app/components/appeals-app-services/variables.tf
@@ -224,3 +224,9 @@ variable "tags" {
   description = "The tags applied to all resources"
   type        = map(string)
 }
+
+variable "allow_testing_overrides" {
+  description = "A switch to determine if testing overrides are enabled to allow easier manual testing"
+  type        = bool
+  default     = false
+}

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -9,6 +9,7 @@ This component contains the infrastructure required for the appeals service. Thi
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.1.6 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.6.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~>0.9 |
 
 ## Providers
 
@@ -16,7 +17,7 @@ This component contains the infrastructure required for the appeals service. Thi
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.6.0 |
 | <a name="provider_azurerm.tooling"></a> [azurerm.tooling](#provider\_azurerm.tooling) | 3.6.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
 
 ## Modules
 
@@ -46,6 +47,7 @@ This component contains the infrastructure required for the appeals service. Thi
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
+| <a name="input_allow_testing_overrides"></a> [allow\_testing\_overrides](#input\_allow\_testing\_overrides) | A switch to determine if testing overrides are enabled to allow easier manual testing | `bool` | `false` | no |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_appeal_documents_primary_blob_connection_string"></a> [appeal\_documents\_primary\_blob\_connection\_string](#input\_appeal\_documents\_primary\_blob\_connection\_string) | The Appeal Documents Storage Account blob connection string associated with the primary location | `string` | n/a | yes |

--- a/app/stacks/uk-south/appeals-service/app-service.tf
+++ b/app/stacks/uk-south/appeals-service/app-service.tf
@@ -46,6 +46,7 @@ module "app_services" {
   srv_notify_service_id                                                       = var.srv_notify_service_id
   task_submit_to_horizon_cron_string                                          = var.task_submit_to_horizon_cron_string
   task_submit_to_horizon_trigger_active                                       = var.task_submit_to_horizon_trigger_active
+  allow_testing_overrides                                                     = var.allow_testing_overrides
 
   tags = local.tags
 

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -222,3 +222,9 @@ variable "task_submit_to_horizon_trigger_active" {
   description = "Task to submit to horizon trigger active"
   type        = string
 }
+
+variable "allow_testing_overrides" {
+  description = "A switch to determine if testing overrides are enabled to allow easier manual testing"
+  type        = bool
+  default     = false
+}

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -59,6 +59,7 @@ This component contains the infrastructure required for the appeals service. Thi
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_action_group_low_id"></a> [action\_group\_low\_id](#input\_action\_group\_low\_id) | The ID of the Azure Monitor action group for low priority (P4) alerts | `string` | n/a | yes |
+| <a name="input_allow_testing_overrides"></a> [allow\_testing\_overrides](#input\_allow\_testing\_overrides) | A switch to determine if testing overrides are enabled to allow easier manual testing | `bool` | `false` | no |
 | <a name="input_api_timeout"></a> [api\_timeout](#input\_api\_timeout) | The timeout in milliseconds for API calls in the frontend apps | `string` | n/a | yes |
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | The id of the app service plan | `string` | n/a | yes |
 | <a name="input_appeals_feature_flags"></a> [appeals\_feature\_flags](#input\_appeals\_feature\_flags) | A list of maps describing feature flags to be saved in the App Configuration store | `list(any)` | n/a | yes |

--- a/app/stacks/uk-west/appeals-service/app-service.tf
+++ b/app/stacks/uk-west/appeals-service/app-service.tf
@@ -44,6 +44,7 @@ module "app_services" {
   srv_notify_service_id                                                       = var.srv_notify_service_id
   task_submit_to_horizon_cron_string                                          = var.task_submit_to_horizon_cron_string
   task_submit_to_horizon_trigger_active                                       = var.task_submit_to_horizon_trigger_active
+  allow_testing_overrides                                                     = var.allow_testing_overrides
 
   tags = local.tags
 

--- a/app/stacks/uk-west/appeals-service/variables.tf
+++ b/app/stacks/uk-west/appeals-service/variables.tf
@@ -209,3 +209,9 @@ variable "task_submit_to_horizon_trigger_active" {
   description = "Task to submit to horizon trigger active"
   type        = string
 }
+
+variable "allow_testing_overrides" {
+  description = "A switch to determine if testing overrides are enabled to allow easier manual testing"
+  type        = bool
+  default     = false
+}

--- a/config/variables/stacks/appeals-service/dev.hcl
+++ b/config/variables/stacks/appeals-service/dev.hcl
@@ -42,4 +42,5 @@ locals {
   srv_notify_failure_to_upload_to_horizon_template_id                         = "49413491-90fd-4ce8-b061-e2f4758b636b"
   task_submit_to_horizon_cron_string                                          = "*/10 * * * *"
   task_submit_to_horizon_trigger_active                                       = "true"
+  allow_testing_overrides                                                     = true
 }

--- a/config/variables/stacks/appeals-service/prod.hcl
+++ b/config/variables/stacks/appeals-service/prod.hcl
@@ -42,4 +42,5 @@ locals {
   srv_notify_failure_to_upload_to_horizon_template_id                         = "68fbc646-c4b4-4050-be04-1829a0b109dc"
   task_submit_to_horizon_cron_string                                          = "*/15 * * * *"
   task_submit_to_horizon_trigger_active                                       = "true"
+  allow_testing_overrides                                                     = false
 }

--- a/config/variables/stacks/appeals-service/test.hcl
+++ b/config/variables/stacks/appeals-service/test.hcl
@@ -42,4 +42,5 @@ locals {
   srv_notify_failure_to_upload_to_horizon_template_id                         = "49413491-90fd-4ce8-b061-e2f4758b636b"
   task_submit_to_horizon_cron_string                                          = "*/10 * * * *"
   task_submit_to_horizon_trigger_active                                       = "true"
+  allow_testing_overrides                                                     = true
 }


### PR DESCRIPTION
Add ALLOW_TESTING_OVERRIDES to allow custom testing code to be used in non prod environment