### PR TITLE
fix(appeals/web): document storage cors

### DIFF
--- a/app/stacks/uk-west/back-office/storage-account.tf
+++ b/app/stacks/uk-west/back-office/storage-account.tf
@@ -21,7 +21,7 @@ resource "azurerm_storage_account" "back_office_documents" {
     cors_rule {
       allowed_headers    = ["*"]
       allowed_methods    = ["GET", "OPTIONS", "PUT"]
-      allowed_origins    = ["https://back-office-${var.environment}.planninginspectorate.gov.uk"]
+      allowed_origins    = ["https://back-office-${var.environment}.planninginspectorate.gov.uk", "https://back-office-appeals-${var.environment}.planninginspectorate.gov.uk"]
       exposed_headers    = ["*"]
       max_age_in_seconds = "600"
     }


### PR DESCRIPTION
Adds the new appeals wfe domain to storage cors settings.