### PR TITLE
fix(appeals/web): document storage permissions

### DIFF
--- a/app/components/back-office-app-services/iam.tf
+++ b/app/components/back-office-app-services/iam.tf
@@ -30,7 +30,7 @@ resource "azurerm_role_assignment" "back_office_app_send_service_bus_access" {
 }
 
 # As above, assume appeals will choose its own topics to publish to on the same service bus instance
-resource "azurerm_role_assignment" "back_office_app_send_service_bus_access" {
+resource "azurerm_role_assignment" "back_office_appeals_send_service_bus_access" {
   scope                = var.service_bus_namespace_id
   role_definition_name = "Azure Service Bus Data Sender"
   principal_id         = module.app_service["back_office_appeals-api"].principal_id

--- a/app/components/back-office-app-services/iam.tf
+++ b/app/components/back-office-app-services/iam.tf
@@ -10,9 +10,28 @@ resource "azurerm_role_assignment" "applications_caseteam_documents_access" {
   principal_id         = var.azuread_applications_caseteam_group_id
 }
 
+resource "azurerm_role_assignment" "appeals_case_officer_documents_access" {
+  scope                = var.document_storage_back_office_document_service_uploads_container_resource_manager_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.azuread_appeals_case_officer_group_id
+}
+
+resource "azurerm_role_assignment" "appeals_inspector_documents_access" {
+  scope                = var.document_storage_back_office_document_service_uploads_container_resource_manager_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.azuread_appeals_inspector_group_id
+}
+
 # For now, allow the back office to publish to all topics in the namespace - we can scope this down to topics later
 resource "azurerm_role_assignment" "back_office_app_send_service_bus_access" {
   scope                = var.service_bus_namespace_id
   role_definition_name = "Azure Service Bus Data Sender"
   principal_id         = module.app_service["back_office_api"].principal_id
+}
+
+# As above, assume appeals will choose its own topics to publish to on the same service bus instance
+resource "azurerm_role_assignment" "back_office_app_send_service_bus_access" {
+  scope                = var.service_bus_namespace_id
+  role_definition_name = "Azure Service Bus Data Sender"
+  principal_id         = module.app_service["back_office_appeals-api"].principal_id
 }


### PR DESCRIPTION
Adds permissions for:

- appeal case officers -> write to blob storage
- appeal inspectors -> write to blob storage
- appeals api -> write to service bus