### PR TITLE
Feature/appealsfo clam server subnet

### DIFF
--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -166,6 +166,7 @@ locals {
       app_service_private_dns_zone_id = var.app_service_private_dns_zone_id
       endpoint_subnet_id              = var.private_endpoint_enabled ? var.endpoint_subnet_id : null
       image_name                      = "appeal-planning-decision/clamav-api"
+      integration_subnet_id           = var.integration_subnet_id
       inbound_vnet_connectivity       = var.private_endpoint_enabled
       key_vault_access                = true
       outbound_vnet_connectivity      = true


### PR DESCRIPTION
Need to add the integration subnet to the clam rest server for appeals front office so we can use outbound vnet connectivity