### PR TITLE
Add WAF exclusion for BO updates: XSS Filter - Category 5

### DIFF
--- a/app/stacks/global/front-door/waf-policy.tf
+++ b/app/stacks/global/front-door/waf-policy.tf
@@ -129,6 +129,18 @@ resource "azurerm_frontdoor_firewall_policy" "default" {
           selector       = "backOfficeProjectUpdateContent"
         }
       }
+
+      rule {
+        # XSS Filter - Category 5: Disallowed HTML Attributes
+        rule_id = "941150"
+        action  = "Block"
+
+        exclusion {
+          match_variable = "RequestBodyPostArgNames"
+          operator       = "Equals"
+          selector       = "backOfficeProjectUpdateContent"
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Add exception to WAF for back office HTML on Post.
This should allow html links to be posted as part of the updates generation on form field - backOfficeProjectUpdateContent.