### PR TITLE
Create a separate subscription for deadline submission results

### DIFF
--- a/app/components/back-office-app-services/deadline-submissions-function/function-app.tf
+++ b/app/components/back-office-app-services/deadline-submissions-function/function-app.tf
@@ -35,3 +35,9 @@ resource "azurerm_servicebus_subscription" "deadline_submission_subscription" {
   topic_id           = var.servicebus_topic_deadline_submission_topic_id
   max_delivery_count = 1
 }
+
+resource "azurerm_servicebus_subscription" "deadline_submission_results_subscription" {
+  name               = "deadline-submission-results-subscription"
+  topic_id           = var.servicebus_topic_deadline_submission_topic_id
+  max_delivery_count = 1
+}


### PR DESCRIPTION
Results from the deadline submissions function are published to service bus. A separate subscription will prevent a feedback loop.