### PR TITLE
fix(back-office): ad groups

### DIFF
--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -1,13 +1,17 @@
 locals {
-  node_environment                                 = "production"
-  azuread_auth_client_id                           = "7cab8971-c305-4b9a-82db-21b5fd84efbd"
-  azuread_appeals_case_officer_group_id            = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_appeals_inspector_group_id               = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
-  azuread_appeals_validation_officer_group_id      = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
-  azuread_applications_case_admin_officer_group_id = "b8bb03d5-9162-4f35-9ff3-856be16dff23"
-  azuread_applications_caseteam_group_id           = "ac136ed4-241a-459e-9b4e-267939fd4f08"
-  azuread_applications_inspector_group_id          = "9dbf4271-7823-45ed-b1a7-3712f6f2faa3"
-  service_bus_failover_enabled                     = false
+  node_environment = "production"
+  # Azure AD configuration
+  azuread_auth_client_id = "7cab8971-c305-4b9a-82db-21b5fd84efbd"
+  # Azure AD Appeals Groups
+  azuread_appeals_case_officer_group_id       = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
+  azuread_appeals_inspector_group_id          = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
+  azuread_appeals_validation_officer_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
+  # Azure AD Applications Groups
+  azuread_applications_case_admin_officer_group_id = "5420e6d8-b155-4839-ab97-cc9893cdb628"
+  azuread_applications_caseteam_group_id           = "3cd1a46e-7b0d-48f4-a342-b5eb15344c42"
+  azuread_applications_inspector_group_id          = "b197404b-f185-4d26-9ff8-a4e42d5b3d70"
+
+  service_bus_failover_enabled = false
   sql_database_configuration = {
     max_size_gb               = 2
     short_term_retention_days = 7 # 7-35

--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -3,9 +3,9 @@ locals {
   # Azure AD configuration
   azuread_auth_client_id = "7cab8971-c305-4b9a-82db-21b5fd84efbd"
   # Azure AD Appeals Groups
-  azuread_appeals_case_officer_group_id       = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_appeals_inspector_group_id          = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
-  azuread_appeals_validation_officer_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
+  azuread_appeals_case_officer_group_id       = "cc4133e5-2319-4762-8a7b-33413701210a"
+  azuread_appeals_inspector_group_id          = "0724c372-098d-4eef-acfb-bc85cd483dd1"
+  azuread_appeals_validation_officer_group_id = "369caed5-fe22-445e-8cdc-8b2f6746afc7"
   # Azure AD Applications Groups
   azuread_applications_case_admin_officer_group_id = "5420e6d8-b155-4839-ab97-cc9893cdb628"
   azuread_applications_caseteam_group_id           = "3cd1a46e-7b0d-48f4-a342-b5eb15344c42"

--- a/config/variables/stacks/back-office/prod.hcl
+++ b/config/variables/stacks/back-office/prod.hcl
@@ -1,13 +1,17 @@
 locals {
-  node_environment                                 = "production"
-  azuread_auth_client_id                           = "2dc22997-3900-4602-b3bd-46385b60e2b2"
-  azuread_appeals_case_officer_group_id            = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_appeals_inspector_group_id               = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
-  azuread_appeals_validation_officer_group_id      = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
+  node_environment = "production"
+  # Azure AD configuration
+  azuread_auth_client_id = "2dc22997-3900-4602-b3bd-46385b60e2b2"
+  # Azure AD Appeals Groups
+  azuread_appeals_case_officer_group_id       = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
+  azuread_appeals_inspector_group_id          = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
+  azuread_appeals_validation_officer_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
+  # Azure AD Applications Groups
   azuread_applications_case_admin_officer_group_id = "b8bb03d5-9162-4f35-9ff3-856be16dff23"
   azuread_applications_caseteam_group_id           = "ac136ed4-241a-459e-9b4e-267939fd4f08"
   azuread_applications_inspector_group_id          = "9dbf4271-7823-45ed-b1a7-3712f6f2faa3"
-  service_bus_failover_enabled                     = true
+
+  service_bus_failover_enabled = true
   sql_database_configuration = {
     max_size_gb               = 1024
     short_term_retention_days = 30 # 7-35

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -1,13 +1,17 @@
 locals {
-  node_environment                                 = "production"
-  azuread_auth_client_id                           = "dff02ad8-1efc-4f5f-8b1c-58a93edd14f1"
-  azuread_appeals_case_officer_group_id            = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_appeals_inspector_group_id               = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
-  azuread_appeals_validation_officer_group_id      = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
-  azuread_applications_case_admin_officer_group_id = "b8bb03d5-9162-4f35-9ff3-856be16dff23"
-  azuread_applications_caseteam_group_id           = "ac136ed4-241a-459e-9b4e-267939fd4f08"
-  azuread_applications_inspector_group_id          = "9dbf4271-7823-45ed-b1a7-3712f6f2faa3"
-  service_bus_failover_enabled                     = true
+  node_environment = "production"
+  # Azure AD configuration
+  azuread_auth_client_id = "dff02ad8-1efc-4f5f-8b1c-58a93edd14f1"
+  # Azure AD Appeals Groups
+  azuread_appeals_case_officer_group_id       = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
+  azuread_appeals_inspector_group_id          = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
+  azuread_appeals_validation_officer_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
+  # Azure AD Applications Groups
+  azuread_applications_case_admin_officer_group_id = "b3101fa9-ab47-4eea-9c73-0ea80786131e"
+  azuread_applications_caseteam_group_id           = "885e4cc5-7d12-4035-bfd1-9b1c2087d491"
+  azuread_applications_inspector_group_id          = "38aa94a5-32c1-4330-8451-e18e32ba26cf"
+
+  service_bus_failover_enabled = true
   sql_database_configuration = {
     max_size_gb               = 1024
     short_term_retention_days = 7 # 7-35

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -3,9 +3,9 @@ locals {
   # Azure AD configuration
   azuread_auth_client_id = "dff02ad8-1efc-4f5f-8b1c-58a93edd14f1"
   # Azure AD Appeals Groups
-  azuread_appeals_case_officer_group_id       = "5d82e08c-8f05-40ea-a3df-d306f3a2c870"
-  azuread_appeals_inspector_group_id          = "c921094a-318f-4996-be5e-9bd2ef9b7bdf"
-  azuread_appeals_validation_officer_group_id = "76d99e25-b02b-4400-96d2-bb9393bbdb9d"
+  azuread_appeals_case_officer_group_id       = "e30a4389-029b-4de8-a94b-c492a3a0854a"
+  azuread_appeals_inspector_group_id          = "3cf2c6ae-cd39-4027-accd-3c906b5462d4"
+  azuread_appeals_validation_officer_group_id = "5ab0da43-964d-4897-ae44-880fe7990225"
   # Azure AD Applications Groups
   azuread_applications_case_admin_officer_group_id = "b3101fa9-ab47-4eea-9c73-0ea80786131e"
   azuread_applications_caseteam_group_id           = "885e4cc5-7d12-4035-bfd1-9b1c2087d491"


### PR DESCRIPTION
Back Office: Use (dev) and (test) AD groups for access to the corresponding environments.