### PR TITLE
feat(applications-service): add failover group for applications db

### DIFF
--- a/app/stacks/uk-south/applications-service/README.md
+++ b/app/stacks/uk-south/applications-service/README.md
@@ -36,6 +36,7 @@ This component contains the infrastructure required for the applications service
 | [azurerm_local_network_gateway.national_infrastructure](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/local_network_gateway) | resource |
 | [azurerm_log_analytics_workspace.applcations_service](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_database.applications_sql_db](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/mssql_database) | resource |
+| [azurerm_mssql_failover_group.applications_sql_server_failover_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/mssql_failover_group) | resource |
 | [azurerm_mssql_server.applications_sql_server](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/mssql_server) | resource |
 | [azurerm_private_dns_zone.redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.redis_cache_dns](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
@@ -112,6 +113,8 @@ This component contains the infrastructure required for the applications service
 | <a name="input_national_infrastructure_gateway_ip"></a> [national\_infrastructure\_gateway\_ip](#input\_national\_infrastructure\_gateway\_ip) | The public IP address of the National Infrastructure gateway endpoint | `string` | n/a | yes |
 | <a name="input_national_infrastructure_vnet_address_space"></a> [national\_infrastructure\_vnet\_address\_space](#input\_national\_infrastructure\_vnet\_address\_space) | The address space advertised by the National Infrastructure gateway endpoint | `list(string)` | n/a | yes |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
+| <a name="input_primary_applications_sql_database_id"></a> [primary\_applications\_sql\_database\_id](#input\_primary\_applications\_sql\_database\_id) | ID of the primary (ukw) Applications SQL database | `string` | n/a | yes |
+| <a name="input_primary_applications_sql_server_id"></a> [primary\_applications\_sql\_server\_id](#input\_primary\_applications\_sql\_server\_id) | ID of the primary (ukw) Applications SQL Server | `string` | n/a | yes |
 | <a name="input_private_beta_v1_routes_only"></a> [private\_beta\_v1\_routes\_only](#input\_private\_beta\_v1\_routes\_only) | Feature toggle for limiting web app routes to Private Beta V1 functionality only | `string` | n/a | yes |
 | <a name="input_private_endpoint_enabled"></a> [private\_endpoint\_enabled](#input\_private\_endpoint\_enabled) | A switch to determine if Private Endpoint should be enabled for backend App Services | `bool` | `true` | no |
 | <a name="input_project_migration_case_references"></a> [project\_migration\_case\_references](#input\_project\_migration\_case\_references) | Specifies the case references to migrate to the new project information page | `string` | n/a | yes |

--- a/app/stacks/uk-south/applications-service/database.tf
+++ b/app/stacks/uk-south/applications-service/database.tf
@@ -60,6 +60,22 @@ resource "azurerm_private_endpoint" "applications_sql_server" {
   tags = local.tags
 }
 
+resource "azurerm_mssql_failover_group" "applications_sql_server_failover_group" {
+  name      = "pins-sqldb-fog-${local.service_name}-${local.resource_suffix}"
+  server_id = var.primary_applications_sql_server_id
+  databases = [var.primary_applications_sql_database_id]
+
+  partner_server {
+    id = azurerm_mssql_server.applications_sql_server.id
+  }
+
+  read_write_endpoint_failover_policy {
+    mode = "Manual"
+  }
+
+  tags = local.tags
+}
+
 resource "random_password" "applications_sql_server_password" {
   length           = 32
   special          = true

--- a/app/stacks/uk-south/applications-service/terragrunt.hcl
+++ b/app/stacks/uk-south/applications-service/terragrunt.hcl
@@ -38,8 +38,10 @@ dependency "applications_service_ukw" {
   mock_outputs_merge_with_state           = true
 
   mock_outputs = {
-    function_storage_name               = "mock-storage-name"
-    function_storage_primary_access_key = "mock-storage-key"
+    function_storage_name                = "mock-storage-name"
+    function_storage_primary_access_key  = "mock-storage-key"
+    primary_applications_sql_server_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Sql/servers/mock_sql_server"
+    primary_applications_sql_database_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Sql/servers/mock_sql_server/databases/mock_sql_db"
   }
 }
 
@@ -81,14 +83,16 @@ inputs = {
   #  back_office_service_bus_deadline_submission_topic_id           = dependency.back_office_uks.outputs.servicebus_topic_deadline_submission_topic_id
   #  back_office_service_bus_namespace_name                         = "mock-namespace"
 
-  common_resource_group_name          = dependency.common_uks.outputs.common_resource_group_name
-  common_vnet_cidr_blocks             = dependency.common_uks.outputs.common_vnet_cidr_blocks
-  common_vnet_gateway_id              = try(dependency.common_uks.outputs.common_vnet_gateway_id, null)
-  common_vnet_id                      = dependency.common_uks.outputs.vnet_id
-  common_vnet_name                    = dependency.common_uks.outputs.common_vnet_name
-  function_storage_name               = dependency.applications_service_ukw.outputs.function_storage_name
-  function_storage_primary_access_key = dependency.applications_service_ukw.outputs.function_storage_primary_access_key
-  integration_subnet_id               = dependency.common_uks.outputs.integration_subnet_id
-  key_vault_id                        = dependency.common_ukw.outputs.key_vault_id
-  key_vault_uri                       = dependency.common_ukw.outputs.key_vault_uri
+  common_resource_group_name           = dependency.common_uks.outputs.common_resource_group_name
+  common_vnet_cidr_blocks              = dependency.common_uks.outputs.common_vnet_cidr_blocks
+  common_vnet_gateway_id               = try(dependency.common_uks.outputs.common_vnet_gateway_id, null)
+  common_vnet_id                       = dependency.common_uks.outputs.vnet_id
+  common_vnet_name                     = dependency.common_uks.outputs.common_vnet_name
+  function_storage_name                = dependency.applications_service_ukw.outputs.function_storage_name
+  function_storage_primary_access_key  = dependency.applications_service_ukw.outputs.function_storage_primary_access_key
+  integration_subnet_id                = dependency.common_uks.outputs.integration_subnet_id
+  key_vault_id                         = dependency.common_ukw.outputs.key_vault_id
+  key_vault_uri                        = dependency.common_ukw.outputs.key_vault_uri
+  primary_applications_sql_server_id   = dependency.applications_service_ukw.outputs.primary_applications_sql_server_id
+  primary_applications_sql_database_id = dependency.applications_service_ukw.outputs.primary_applications_sql_database_id
 }

--- a/app/stacks/uk-south/applications-service/variables.tf
+++ b/app/stacks/uk-south/applications-service/variables.tf
@@ -311,6 +311,16 @@ variable "node_environment" {
   default     = "development"
 }
 
+variable "primary_applications_sql_server_id" {
+  description = "ID of the primary (ukw) Applications SQL Server"
+  type        = string
+}
+
+variable "primary_applications_sql_database_id" {
+  description = "ID of the primary (ukw) Applications SQL database"
+  type        = string
+}
+
 variable "private_endpoint_enabled" {
   description = "A switch to determine if Private Endpoint should be enabled for backend App Services"
   type        = bool

--- a/app/stacks/uk-west/applications-service/README.md
+++ b/app/stacks/uk-west/applications-service/README.md
@@ -130,5 +130,7 @@ This component contains the infrastructure required for the applications service
 | <a name="output_app_service_urls"></a> [app\_service\_urls](#output\_app\_service\_urls) | A map of frontend app service URLs |
 | <a name="output_function_storage_name"></a> [function\_storage\_name](#output\_function\_storage\_name) | Name of the Storage Account used for Function Apps |
 | <a name="output_function_storage_primary_access_key"></a> [function\_storage\_primary\_access\_key](#output\_function\_storage\_primary\_access\_key) | Primary access key of the Storage Account used for Function Apps |
+| <a name="output_primary_applications_sql_database_id"></a> [primary\_applications\_sql\_database\_id](#output\_primary\_applications\_sql\_database\_id) | ID of the primary (ukw) Applications SQL database |
+| <a name="output_primary_applications_sql_server_id"></a> [primary\_applications\_sql\_server\_id](#output\_primary\_applications\_sql\_server\_id) | ID of the primary (ukw) Applications SQL Server |
 | <a name="output_web_frontend_url"></a> [web\_frontend\_url](#output\_web\_frontend\_url) | The URL of the web frontend app service |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/uk-west/applications-service/outputs.tf
+++ b/app/stacks/uk-west/applications-service/outputs.tf
@@ -3,11 +3,6 @@ output "app_service_urls" {
   value       = module.app_services.app_service_urls
 }
 
-output "web_frontend_url" {
-  description = "The URL of the web frontend app service"
-  value       = module.app_services.web_frontend_url
-}
-
 output "function_storage_name" {
   description = "Name of the Storage Account used for Function Apps"
   value       = azurerm_storage_account.function_storage.name
@@ -17,4 +12,19 @@ output "function_storage_primary_access_key" {
   description = "Primary access key of the Storage Account used for Function Apps"
   value       = azurerm_storage_account.function_storage.primary_access_key
   sensitive   = true
+}
+
+output "primary_applications_sql_server_id" {
+  description = "ID of the primary (ukw) Applications SQL Server"
+  value       = azurerm_mssql_server.applications_sql_server.id
+}
+
+output "primary_applications_sql_database_id" {
+  description = "ID of the primary (ukw) Applications SQL database"
+  value       = azurerm_mssql_database.applications_sql_db.id
+}
+
+output "web_frontend_url" {
+  description = "The URL of the web frontend app service"
+  value       = module.app_services.web_frontend_url
 }


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

ASB-1949

Adds failover group for Applications front office Azure SQL server and database.

Set to manual failover until a disaster recovery strategy is defined

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money @Philip-Philippou1 this will incur cost
