### PR TITLE
fix(applications-service): add subscription rule for nsip-exam-timetable

### DIFF
--- a/app/components/applications-app-services/README.md
+++ b/app/components/applications-app-services/README.md
@@ -42,6 +42,7 @@ This module contains the App Services resources for the applications service. Th
 | [azurerm_servicebus_subscription.nsip_project_update_topic_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription) | resource |
 | [azurerm_servicebus_subscription.nsip_project_update_unpublish_topic_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription) | resource |
 | [azurerm_servicebus_subscription.nsip_representation_topic_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription) | resource |
+| [azurerm_servicebus_subscription_rule.nsip_exam_timetable_topic_subscription_rule](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription_rule) | resource |
 | [azurerm_servicebus_subscription_rule.nsip_project_topic_subscription_rule](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription_rule) | resource |
 | [azurerm_servicebus_subscription_rule.nsip_project_update_topic_subscription_rule](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription_rule) | resource |
 | [azurerm_servicebus_subscription_rule.nsip_project_update_unpublish_topic_subscription_rule](https://registry.terraform.io/providers/hashicorp/azurerm/3.64.0/docs/resources/servicebus_subscription_rule) | resource |

--- a/app/components/applications-app-services/function-app.tf
+++ b/app/components/applications-app-services/function-app.tf
@@ -175,3 +175,16 @@ resource "azurerm_role_assignment" "nsip_exam_timetable_service_bus_role" {
   role_definition_name = "Azure Service Bus Data Receiver"
   principal_id         = module.back_office_subscribers[0].principal_id
 }
+
+resource "azurerm_servicebus_subscription_rule" "nsip_exam_timetable_topic_subscription_rule" {
+  count = var.feature_back_office_subscriber_enabled ? 1 : 0
+
+  name            = "applications-nsip-exam-timetable-subscription-rule"
+  subscription_id = azurerm_servicebus_subscription.nsip_exam_timetable_topic_subscription[0].id
+  filter_type     = "CorrelationFilter"
+  correlation_filter {
+    properties = {
+      type = "Publish"
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Add subscription rule for `"applications-nsip-exam-timetable"` subscription, so that subscriber function will only be invoked when incoming message has `type` header set to `Publish` (otherwise function will also invoke on other types, such as `Unpublish`)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
