### PR TITLE
feat(appeals-fo): remove redundant sql db and reuse ukw login for uks

### DIFF
--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -91,7 +91,8 @@ locals {
         SERVER_TERMINATION_GRACE_PERIOD_SECONDS                                     = "0"
         SERVICE_BUS_HOSTNAME                                                        = "${var.back_office_service_bus_namespace_name}.servicebus.windows.net"
         SERVICE_BUS_ENABLED                                                         = var.appeals_api_service_bus_enabled
-        SQL_CONNECTION_STRING                                                       = local.secret_refs["appeals-sql-server-connection-string-admin"]
+        SQL_CONNECTION_STRING_ADMIN                                                 = local.secret_refs["appeals-sql-server-connection-string-admin"]
+        SQL_CONNECTION_STRING                                                       = local.secret_refs["appeals-sql-server-connection-string-app"]
         SRV_ADMIN_MONITORING_EMAIL                                                  = var.srv_admin_monitoring_email
         SRV_HORIZON_URL                                                             = var.horizon_url
         SRV_NOTIFY_API_KEY                                                          = local.secret_refs["appeals-srv-notify-api-key"]
@@ -196,7 +197,8 @@ locals {
     "appeals-mongo-db-connection-string",
     "appeals-horizon-pub-password",
     "appeals-documents-primary-blob-connection-string",
-    "appeals-sql-server-connection-string-admin"
+    "appeals-sql-server-connection-string-admin",
+    "appeals-sql-server-connection-string-app"
   ]
 
   secret_names = concat(local.secrets_manual, local.secrets_automated)

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -16,7 +16,6 @@ This component contains the infrastructure required for the appeals service. Thi
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.74.0 |
 | <a name="provider_azurerm.tooling"></a> [azurerm.tooling](#provider\_azurerm.tooling) | 3.74.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
 
 ## Modules
@@ -41,15 +40,12 @@ This component contains the infrastructure required for the appeals service. Thi
 | [azurerm_key_vault_secret.appeals_sql_server_username_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.applications_insights_connection_kv_secret](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/log_analytics_workspace) | resource |
-| [azurerm_mssql_database.appeals_sql_db](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/mssql_database) | resource |
 | [azurerm_mssql_failover_group.appeals_sql_server_failover_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/mssql_failover_group) | resource |
 | [azurerm_mssql_server.appeals_sql_server](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/mssql_server) | resource |
 | [azurerm_private_endpoint.appeals_app_config](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.appeals_sql_server](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.appeals_service_stack](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/resource_group) | resource |
 | [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/subnet) | resource |
-| [random_id.username_suffix_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [random_password.appeals_sql_server_password_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [time_offset.secret_expire_date](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/offset) | resource |
 | [azurerm_private_dns_zone.app_config](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.app_service](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/data-sources/private_dns_zone) | data source |
@@ -96,6 +92,7 @@ This component contains the infrastructure required for the appeals service. Thi
 | <a name="input_monitoring_alerts_enabled"></a> [monitoring\_alerts\_enabled](#input\_monitoring\_alerts\_enabled) | Indicates whether Azure Monitor alerts are enabled for App Service | `bool` | `false` | no |
 | <a name="input_node_environment"></a> [node\_environment](#input\_node\_environment) | The node environment to be used for applications in this environment e.g. development | `string` | `"development"` | no |
 | <a name="input_primary_appeals_sql_database_id"></a> [primary\_appeals\_sql\_database\_id](#input\_primary\_appeals\_sql\_database\_id) | ID of the primary (ukw) Appeals SQL database | `string` | n/a | yes |
+| <a name="input_primary_appeals_sql_database_name"></a> [primary\_appeals\_sql\_database\_name](#input\_primary\_appeals\_sql\_database\_name) | Name of the primary (ukw) Appeals SQL database | `string` | n/a | yes |
 | <a name="input_primary_appeals_sql_server_id"></a> [primary\_appeals\_sql\_server\_id](#input\_primary\_appeals\_sql\_server\_id) | ID of the primary (ukw) Appeals SQL Server | `string` | n/a | yes |
 | <a name="input_private_endpoint_enabled"></a> [private\_endpoint\_enabled](#input\_private\_endpoint\_enabled) | A switch to determine if Private Endpoint should be enabled for backend App Services | `bool` | `true` | no |
 | <a name="input_service_bus_appeals_bo_case_topic_id"></a> [service\_bus\_appeals\_bo\_case\_topic\_id](#input\_service\_bus\_appeals\_bo\_case\_topic\_id) | ID for the appeals case data topic | `string` | n/a | yes |
@@ -103,8 +100,9 @@ This component contains the infrastructure required for the appeals service. Thi
 | <a name="input_service_bus_appeals_fo_appellant_submission_topic_id"></a> [service\_bus\_appeals\_fo\_appellant\_submission\_topic\_id](#input\_service\_bus\_appeals\_fo\_appellant\_submission\_topic\_id) | ID for the appeals fo front office LPA response submission topic | `string` | n/a | yes |
 | <a name="input_service_bus_appeals_fo_lpa_response_submission_topic_id"></a> [service\_bus\_appeals\_fo\_lpa\_response\_submission\_topic\_id](#input\_service\_bus\_appeals\_fo\_lpa\_response\_submission\_topic\_id) | ID for the appeals fo front office LPA response submission topic | `string` | n/a | yes |
 | <a name="input_service_bus_listed_building_topic_id"></a> [service\_bus\_listed\_building\_topic\_id](#input\_service\_bus\_listed\_building\_topic\_id) | ID for the listed building topic | `string` | n/a | yes |
-| <a name="input_sql_database_configuration"></a> [sql\_database\_configuration](#input\_sql\_database\_configuration) | A map of database configuration options | `map(string)` | n/a | yes |
 | <a name="input_sql_server_azuread_administrator"></a> [sql\_server\_azuread\_administrator](#input\_sql\_server\_azuread\_administrator) | Azure AD details of database administrator user/group | `map(string)` | n/a | yes |
+| <a name="input_sql_server_password_admin"></a> [sql\_server\_password\_admin](#input\_sql\_server\_password\_admin) | The SQL server administrator password | `string` | n/a | yes |
+| <a name="input_sql_server_username_admin"></a> [sql\_server\_username\_admin](#input\_sql\_server\_username\_admin) | The SQL server administrator username | `string` | n/a | yes |
 | <a name="input_srv_admin_monitoring_email"></a> [srv\_admin\_monitoring\_email](#input\_srv\_admin\_monitoring\_email) | Email for the Horizon failure team | `string` | n/a | yes |
 | <a name="input_srv_notify_appeal_submission_confirmation_email_to_appellant_template_id"></a> [srv\_notify\_appeal\_submission\_confirmation\_email\_to\_appellant\_template\_id](#input\_srv\_notify\_appeal\_submission\_confirmation\_email\_to\_appellant\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_srv_notify_appeal_submission_received_notification_email_to_lpa_template_id"></a> [srv\_notify\_appeal\_submission\_received\_notification\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_appeal\_submission\_received\_notification\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |

--- a/app/stacks/uk-south/appeals-service/README.md
+++ b/app/stacks/uk-south/appeals-service/README.md
@@ -36,8 +36,11 @@ This component contains the infrastructure required for the appeals service. Thi
 | [azurerm_key_vault_secret.appeals_horizon_service_bus_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_mongo_db_connection_secret](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_sql_server_connection_string_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.appeals_sql_server_connection_string_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_sql_server_password_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.appeals_sql_server_password_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_sql_server_username_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.appeals_sql_server_username_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.applications_insights_connection_kv_secret](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_failover_group.appeals_sql_server_failover_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/mssql_failover_group) | resource |
@@ -102,7 +105,9 @@ This component contains the infrastructure required for the appeals service. Thi
 | <a name="input_service_bus_listed_building_topic_id"></a> [service\_bus\_listed\_building\_topic\_id](#input\_service\_bus\_listed\_building\_topic\_id) | ID for the listed building topic | `string` | n/a | yes |
 | <a name="input_sql_server_azuread_administrator"></a> [sql\_server\_azuread\_administrator](#input\_sql\_server\_azuread\_administrator) | Azure AD details of database administrator user/group | `map(string)` | n/a | yes |
 | <a name="input_sql_server_password_admin"></a> [sql\_server\_password\_admin](#input\_sql\_server\_password\_admin) | The SQL server administrator password | `string` | n/a | yes |
+| <a name="input_sql_server_password_app"></a> [sql\_server\_password\_app](#input\_sql\_server\_password\_app) | The SQL server app password | `string` | n/a | yes |
 | <a name="input_sql_server_username_admin"></a> [sql\_server\_username\_admin](#input\_sql\_server\_username\_admin) | The SQL server administrator username | `string` | n/a | yes |
+| <a name="input_sql_server_username_app"></a> [sql\_server\_username\_app](#input\_sql\_server\_username\_app) | The SQL server app username | `string` | n/a | yes |
 | <a name="input_srv_admin_monitoring_email"></a> [srv\_admin\_monitoring\_email](#input\_srv\_admin\_monitoring\_email) | Email for the Horizon failure team | `string` | n/a | yes |
 | <a name="input_srv_notify_appeal_submission_confirmation_email_to_appellant_template_id"></a> [srv\_notify\_appeal\_submission\_confirmation\_email\_to\_appellant\_template\_id](#input\_srv\_notify\_appeal\_submission\_confirmation\_email\_to\_appellant\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |
 | <a name="input_srv_notify_appeal_submission_received_notification_email_to_lpa_template_id"></a> [srv\_notify\_appeal\_submission\_received\_notification\_email\_to\_lpa\_template\_id](#input\_srv\_notify\_appeal\_submission\_received\_notification\_email\_to\_lpa\_template\_id) | A template ID required by the Appeals Service API | `string` | n/a | yes |

--- a/app/stacks/uk-south/appeals-service/database.tf
+++ b/app/stacks/uk-south/appeals-service/database.tf
@@ -10,8 +10,8 @@ resource "azurerm_mssql_server" "appeals_sql_server" {
   minimum_tls_version           = "1.2"
   public_network_access_enabled = var.database_public_access_enabled
 
-  administrator_login          = local.sql_server_username_admin
-  administrator_login_password = random_password.appeals_sql_server_password_admin.result
+  administrator_login          = var.sql_server_username_admin
+  administrator_login_password = var.sql_server_password_admin
 
   azuread_administrator {
     login_username = var.sql_server_azuread_administrator["login_username"]
@@ -20,27 +20,6 @@ resource "azurerm_mssql_server" "appeals_sql_server" {
 
   identity {
     type = "SystemAssigned"
-  }
-
-  tags = local.tags
-}
-
-resource "azurerm_mssql_database" "appeals_sql_db" {
-  name        = "pins-sqldb-${local.service_name}-${local.resource_suffix}"
-  server_id   = azurerm_mssql_server.appeals_sql_server.id
-  collation   = "SQL_Latin1_General_CP1_CI_AS"
-  sku_name    = var.sql_database_configuration["sku_name"]
-  max_size_gb = var.sql_database_configuration["max_size_gb"]
-
-  short_term_retention_policy {
-    retention_days = var.sql_database_configuration["short_term_retention_days"]
-  }
-
-  long_term_retention_policy {
-    weekly_retention  = var.sql_database_configuration["long_term_retention_weekly"]
-    monthly_retention = var.sql_database_configuration["long_term_retention_monthly"]
-    yearly_retention  = var.sql_database_configuration["long_term_retention_yearly"]
-    week_of_year      = var.sql_database_configuration["long_term_week_of_year"]
   }
 
   tags = local.tags
@@ -81,18 +60,4 @@ resource "azurerm_mssql_failover_group" "appeals_sql_server_failover_group" {
   }
 
   tags = local.tags
-}
-
-resource "random_password" "appeals_sql_server_password_admin" {
-  length           = 32
-  special          = true
-  override_special = "#&-_+"
-  min_lower        = 2
-  min_upper        = 2
-  min_numeric      = 2
-  min_special      = 2
-}
-
-resource "random_id" "username_suffix_admin" {
-  byte_length = 6
 }

--- a/app/stacks/uk-south/appeals-service/locals.tf
+++ b/app/stacks/uk-south/appeals-service/locals.tf
@@ -13,6 +13,17 @@ locals {
       "encrypt=true"
     ]
   )
+  sql_connection_string_app = join(
+    ";",
+    [
+      "sqlserver://${azurerm_mssql_server.appeals_sql_server.fully_qualified_domain_name}",
+      "database=${var.primary_appeals_sql_database_name}",
+      "user=${var.sql_server_username_app}",
+      "password=${var.sql_server_password_app}",
+      "trustServerCertificate=false",
+      "encrypt=true"
+    ]
+  )
 
   tags = merge(
     var.common_tags,

--- a/app/stacks/uk-south/appeals-service/locals.tf
+++ b/app/stacks/uk-south/appeals-service/locals.tf
@@ -2,12 +2,11 @@ locals {
   service_name    = "appeals-service"
   resource_suffix = "${var.environment}-${module.azure_region_uks.location_short}-${var.instance}"
 
-  sql_server_username_admin = "pins-sql-${local.service_name}-${local.resource_suffix}-admin-${random_id.username_suffix_admin.id}"
   sql_connection_string_admin = join(
     ";",
     [
       "sqlserver://${azurerm_mssql_server.appeals_sql_server.fully_qualified_domain_name}",
-      "database=${azurerm_mssql_database.appeals_sql_db.name}",
+      "database=${var.primary_appeals_sql_database_name}",
       "user=${azurerm_mssql_server.appeals_sql_server.administrator_login}",
       "password=${azurerm_mssql_server.appeals_sql_server.administrator_login_password}",
       "trustServerCertificate=false",

--- a/app/stacks/uk-south/appeals-service/secrets.tf
+++ b/app/stacks/uk-south/appeals-service/secrets.tf
@@ -68,6 +68,17 @@ resource "azurerm_key_vault_secret" "appeals_sql_server_password_admin" {
   tags = local.tags
 }
 
+resource "azurerm_key_vault_secret" "appeals_sql_server_password_app" {
+  #checkov:skip=CKV_AZURE_41
+  count        = var.is_dr_deployment ? 1 : 0
+  content_type = "text/plain"
+  key_vault_id = var.key_vault_id
+  name         = "appeals-service-sql-server-password-app"
+  value        = var.sql_server_password_app
+
+  tags = local.tags
+}
+
 resource "azurerm_key_vault_secret" "appeals_sql_server_username_admin" {
   #checkov:skip=CKV_AZURE_41
   count        = var.is_dr_deployment ? 1 : 0
@@ -79,6 +90,17 @@ resource "azurerm_key_vault_secret" "appeals_sql_server_username_admin" {
   tags = local.tags
 }
 
+resource "azurerm_key_vault_secret" "appeals_sql_server_username_app" {
+  #checkov:skip=CKV_AZURE_41
+  count        = var.is_dr_deployment ? 1 : 0
+  content_type = "text/plain"
+  key_vault_id = var.key_vault_id
+  name         = "appeals-service-sql-server-username-app"
+  value        = var.sql_server_username_app
+
+  tags = local.tags
+}
+
 resource "azurerm_key_vault_secret" "appeals_sql_server_connection_string_admin" {
   #checkov:skip=CKV_AZURE_41
   count        = var.is_dr_deployment ? 1 : 0
@@ -86,6 +108,17 @@ resource "azurerm_key_vault_secret" "appeals_sql_server_connection_string_admin"
   key_vault_id = var.key_vault_id
   name         = "appeals-sql-server-connection-string-admin"
   value        = local.sql_connection_string_admin
+
+  tags = local.tags
+}
+
+resource "azurerm_key_vault_secret" "appeals_sql_server_connection_string_app" {
+  #checkov:skip=CKV_AZURE_41
+  count        = var.is_dr_deployment ? 1 : 0
+  content_type = "text/plain"
+  key_vault_id = var.key_vault_id
+  name         = "appeals-sql-server-connection-string-app"
+  value        = local.sql_connection_string_app
 
   tags = local.tags
 }

--- a/app/stacks/uk-south/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-south/appeals-service/terragrunt.hcl
@@ -18,7 +18,9 @@ dependency "appeals_service_ukw" {
     primary_appeals_sql_database_id                 = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Sql/servers/mock_sql_server/databases/mock_sql_db"
     primary_appeals_sql_database_name               = "mock-db-name"
     sql_server_password_admin                       = "mockpass"
+    sql_server_password_app                         = "mockpass2"
     sql_server_username_admin                       = "mockuser"
+    sql_server_username_app                         = "mockuser2"
   }
 }
 
@@ -105,5 +107,7 @@ inputs = {
   primary_appeals_sql_database_id                         = dependency.appeals_service_ukw.outputs.primary_appeals_sql_database_id
   primary_appeals_sql_database_name                       = dependency.appeals_service_ukw.outputs.primary_appeals_sql_database_name
   sql_server_password_admin                               = dependency.appeals_service_ukw.outputs.sql_server_password_admin
+  sql_server_password_app                                 = dependency.appeals_service_ukw.outputs.sql_server_password_app
   sql_server_username_admin                               = dependency.appeals_service_ukw.outputs.sql_server_username_admin
+  sql_server_username_app                                 = dependency.appeals_service_ukw.outputs.sql_server_username_app
 }

--- a/app/stacks/uk-south/appeals-service/terragrunt.hcl
+++ b/app/stacks/uk-south/appeals-service/terragrunt.hcl
@@ -16,6 +16,9 @@ dependency "appeals_service_ukw" {
     function_apps_storage_account_access_key        = "mockaccesskey"
     primary_appeals_sql_server_id                   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Sql/servers/mock_sql_server"
     primary_appeals_sql_database_id                 = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mock_resource_group/providers/Microsoft.Sql/servers/mock_sql_server/databases/mock_sql_db"
+    primary_appeals_sql_database_name               = "mock-db-name"
+    sql_server_password_admin                       = "mockpass"
+    sql_server_username_admin                       = "mockuser"
   }
 }
 
@@ -100,4 +103,7 @@ inputs = {
   clamav_host                                             = dependency.back_office_ukw.outputs.clamav_host
   primary_appeals_sql_server_id                           = dependency.appeals_service_ukw.outputs.primary_appeals_sql_server_id
   primary_appeals_sql_database_id                         = dependency.appeals_service_ukw.outputs.primary_appeals_sql_database_id
+  primary_appeals_sql_database_name                       = dependency.appeals_service_ukw.outputs.primary_appeals_sql_database_name
+  sql_server_password_admin                               = dependency.appeals_service_ukw.outputs.sql_server_password_admin
+  sql_server_username_admin                               = dependency.appeals_service_ukw.outputs.sql_server_username_admin
 }

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -310,12 +310,24 @@ variable "primary_appeals_sql_database_id" {
   type        = string
 }
 
+variable "primary_appeals_sql_database_name" {
+  description = "Name of the primary (ukw) Appeals SQL database"
+  type        = string
+}
+
 variable "sql_server_azuread_administrator" {
   description = "Azure AD details of database administrator user/group"
   type        = map(string)
 }
 
-variable "sql_database_configuration" {
-  description = "A map of database configuration options"
-  type        = map(string)
+variable "sql_server_password_admin" {
+  description = "The SQL server administrator password"
+  sensitive   = true
+  type        = string
+}
+
+variable "sql_server_username_admin" {
+  description = "The SQL server administrator username"
+  sensitive   = true
+  type        = string
 }

--- a/app/stacks/uk-south/appeals-service/variables.tf
+++ b/app/stacks/uk-south/appeals-service/variables.tf
@@ -326,8 +326,20 @@ variable "sql_server_password_admin" {
   type        = string
 }
 
+variable "sql_server_password_app" {
+  description = "The SQL server app password"
+  sensitive   = true
+  type        = string
+}
+
 variable "sql_server_username_admin" {
   description = "The SQL server administrator username"
+  sensitive   = true
+  type        = string
+}
+
+variable "sql_server_username_app" {
+  description = "The SQL server app username"
   sensitive   = true
   type        = string
 }

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -43,8 +43,11 @@ This component contains the infrastructure required for the appeals service. Thi
 | [azurerm_key_vault_secret.appeals_horizon_service_bus_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_mongo_db_connection_secret](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_sql_server_connection_string_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.appeals_sql_server_connection_string_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_sql_server_password_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.appeals_sql_server_password_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.appeals_sql_server_username_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.appeals_sql_server_username_app](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.applications_insights_connection_kv_secret](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_workspace.appeals_service](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_database.appeals_sql_db](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/mssql_database) | resource |
@@ -60,7 +63,9 @@ This component contains the infrastructure required for the appeals service. Thi
 | [azurerm_storage_container.listedbuildings](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/storage_container) | resource |
 | [azurerm_subnet.appeals_service_ingress](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/subnet) | resource |
 | [random_id.username_suffix_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.username_suffix_app](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.appeals_sql_server_password_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.appeals_sql_server_password_app](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [time_offset.secret_expire_date](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/offset) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/data-sources/client_config) | data source |
 | [azurerm_private_dns_zone.app_config](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/data-sources/private_dns_zone) | data source |
@@ -146,6 +151,8 @@ This component contains the infrastructure required for the appeals service. Thi
 | <a name="output_primary_appeals_sql_database_name"></a> [primary\_appeals\_sql\_database\_name](#output\_primary\_appeals\_sql\_database\_name) | Name of the primary (ukw) Appeals SQL Database |
 | <a name="output_primary_appeals_sql_server_id"></a> [primary\_appeals\_sql\_server\_id](#output\_primary\_appeals\_sql\_server\_id) | ID of the primary (ukw) Appeals SQL Server |
 | <a name="output_sql_server_password_admin"></a> [sql\_server\_password\_admin](#output\_sql\_server\_password\_admin) | The SQL server administrator password |
+| <a name="output_sql_server_password_app"></a> [sql\_server\_password\_app](#output\_sql\_server\_password\_app) | The SQL server app password |
 | <a name="output_sql_server_username_admin"></a> [sql\_server\_username\_admin](#output\_sql\_server\_username\_admin) | The SQL server administrator username |
+| <a name="output_sql_server_username_app"></a> [sql\_server\_username\_app](#output\_sql\_server\_username\_app) | The SQL server app username |
 | <a name="output_web_frontend_url"></a> [web\_frontend\_url](#output\_web\_frontend\_url) | The URL of the web frontend app service |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/uk-west/appeals-service/README.md
+++ b/app/stacks/uk-west/appeals-service/README.md
@@ -143,6 +143,9 @@ This component contains the infrastructure required for the appeals service. Thi
 | <a name="output_function_apps_storage_account"></a> [function\_apps\_storage\_account](#output\_function\_apps\_storage\_account) | The name of the storage account used by the Function Apps |
 | <a name="output_function_apps_storage_account_access_key"></a> [function\_apps\_storage\_account\_access\_key](#output\_function\_apps\_storage\_account\_access\_key) | The access key for the storage account used by the Function Apps |
 | <a name="output_primary_appeals_sql_database_id"></a> [primary\_appeals\_sql\_database\_id](#output\_primary\_appeals\_sql\_database\_id) | ID of the primary (ukw) Appeals SQL Database |
+| <a name="output_primary_appeals_sql_database_name"></a> [primary\_appeals\_sql\_database\_name](#output\_primary\_appeals\_sql\_database\_name) | Name of the primary (ukw) Appeals SQL Database |
 | <a name="output_primary_appeals_sql_server_id"></a> [primary\_appeals\_sql\_server\_id](#output\_primary\_appeals\_sql\_server\_id) | ID of the primary (ukw) Appeals SQL Server |
+| <a name="output_sql_server_password_admin"></a> [sql\_server\_password\_admin](#output\_sql\_server\_password\_admin) | The SQL server administrator password |
+| <a name="output_sql_server_username_admin"></a> [sql\_server\_username\_admin](#output\_sql\_server\_username\_admin) | The SQL server administrator username |
 | <a name="output_web_frontend_url"></a> [web\_frontend\_url](#output\_web\_frontend\_url) | The URL of the web frontend app service |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/app/stacks/uk-west/appeals-service/database.tf
+++ b/app/stacks/uk-west/appeals-service/database.tf
@@ -80,3 +80,17 @@ resource "random_password" "appeals_sql_server_password_admin" {
 resource "random_id" "username_suffix_admin" {
   byte_length = 6
 }
+
+resource "random_password" "appeals_sql_server_password_app" {
+  length           = 32
+  special          = true
+  override_special = "#&-_+"
+  min_lower        = 2
+  min_upper        = 2
+  min_numeric      = 2
+  min_special      = 2
+}
+
+resource "random_id" "username_suffix_app" {
+  byte_length = 6
+}

--- a/app/stacks/uk-west/appeals-service/locals.tf
+++ b/app/stacks/uk-west/appeals-service/locals.tf
@@ -3,6 +3,7 @@ locals {
   resource_suffix = "${var.environment}-${module.azure_region_primary.location_short}-${var.instance}"
 
   sql_server_username_admin = "pins-sql-${local.service_name}-${local.resource_suffix}-admin-${random_id.username_suffix_admin.id}"
+  sql_server_username_app   = "pins-sql-${local.service_name}-${local.resource_suffix}-app-${random_id.username_suffix_app.id}"
   sql_connection_string_admin = join(
     ";",
     [
@@ -10,6 +11,17 @@ locals {
       "database=${azurerm_mssql_database.appeals_sql_db.name}",
       "user=${azurerm_mssql_server.appeals_sql_server.administrator_login}",
       "password=${azurerm_mssql_server.appeals_sql_server.administrator_login_password}",
+      "trustServerCertificate=false",
+      "encrypt=true"
+    ]
+  )
+  sql_connection_string_app = join(
+    ";",
+    [
+      "sqlserver://${azurerm_mssql_server.appeals_sql_server.fully_qualified_domain_name}",
+      "database=${azurerm_mssql_database.appeals_sql_db.name}",
+      "user=${local.sql_server_username_app}",
+      "password=${random_password.appeals_sql_server_password_app.result}",
       "trustServerCertificate=false",
       "encrypt=true"
     ]

--- a/app/stacks/uk-west/appeals-service/outputs.tf
+++ b/app/stacks/uk-west/appeals-service/outputs.tf
@@ -62,8 +62,20 @@ output "sql_server_password_admin" {
   value       = random_password.appeals_sql_server_password_admin.result
 }
 
+output "sql_server_password_app" {
+  description = "The SQL server app password"
+  sensitive   = true
+  value       = random_password.appeals_sql_server_password_app.result
+}
+
 output "sql_server_username_admin" {
   description = "The SQL server administrator username"
   sensitive   = true
   value       = local.sql_server_username_admin
+}
+
+output "sql_server_username_app" {
+  description = "The SQL server app username"
+  sensitive   = true
+  value       = local.sql_server_username_app
 }

--- a/app/stacks/uk-west/appeals-service/outputs.tf
+++ b/app/stacks/uk-west/appeals-service/outputs.tf
@@ -50,3 +50,20 @@ output "primary_appeals_sql_database_id" {
   description = "ID of the primary (ukw) Appeals SQL Database"
   value       = azurerm_mssql_database.appeals_sql_db.id
 }
+
+output "primary_appeals_sql_database_name" {
+  description = "Name of the primary (ukw) Appeals SQL Database"
+  value       = azurerm_mssql_database.appeals_sql_db.name
+}
+
+output "sql_server_password_admin" {
+  description = "The SQL server administrator password"
+  sensitive   = true
+  value       = random_password.appeals_sql_server_password_admin.result
+}
+
+output "sql_server_username_admin" {
+  description = "The SQL server administrator username"
+  sensitive   = true
+  value       = local.sql_server_username_admin
+}

--- a/app/stacks/uk-west/appeals-service/secrets.tf
+++ b/app/stacks/uk-west/appeals-service/secrets.tf
@@ -81,6 +81,17 @@ resource "azurerm_key_vault_secret" "appeals_sql_server_password_admin" {
   tags = local.tags
 }
 
+resource "azurerm_key_vault_secret" "appeals_sql_server_password_app" {
+  #checkov:skip=CKV_AZURE_41
+
+  content_type = "text/plain"
+  key_vault_id = var.key_vault_id
+  name         = "appeals-service-sql-server-password-app"
+  value        = random_password.appeals_sql_server_password_app.result
+
+  tags = local.tags
+}
+
 resource "azurerm_key_vault_secret" "appeals_sql_server_username_admin" {
   #checkov:skip=CKV_AZURE_41
 
@@ -92,6 +103,17 @@ resource "azurerm_key_vault_secret" "appeals_sql_server_username_admin" {
   tags = local.tags
 }
 
+resource "azurerm_key_vault_secret" "appeals_sql_server_username_app" {
+  #checkov:skip=CKV_AZURE_41
+
+  content_type = "text/plain"
+  key_vault_id = var.key_vault_id
+  name         = "appeals-service-sql-server-username-app"
+  value        = local.sql_server_username_app
+
+  tags = local.tags
+}
+
 resource "azurerm_key_vault_secret" "appeals_sql_server_connection_string_admin" {
   #checkov:skip=CKV_AZURE_41
 
@@ -99,6 +121,17 @@ resource "azurerm_key_vault_secret" "appeals_sql_server_connection_string_admin"
   key_vault_id = var.key_vault_id
   name         = "appeals-sql-server-connection-string-admin"
   value        = local.sql_connection_string_admin
+
+  tags = local.tags
+}
+
+resource "azurerm_key_vault_secret" "appeals_sql_server_connection_string_app" {
+  #checkov:skip=CKV_AZURE_41
+
+  content_type = "text/plain"
+  key_vault_id = var.key_vault_id
+  name         = "appeals-sql-server-connection-string-app"
+  value        = local.sql_connection_string_app
 
   tags = local.tags
 }


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Looks as if  the definition of the failover group is enough to create the db in uk south, as such have removed the redundant second db in uk south

Have also reused the admin login details from ukw sql server in uks

Have added an application user to used as a connection string in place of admin login to reduce permissions that the apps connecting to the db have. These will have to be manually added as logins/user to sql server after creation


<!--
Issue ticket number and link

Please include a summary of the change along with any relevant context.
List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
