### PR TITLE
Pass back_office_documents to document-check as an excluded account

### DIFF
--- a/app/components/back-office-app-services/doc-scanning.tf
+++ b/app/components/back-office-app-services/doc-scanning.tf
@@ -40,6 +40,7 @@ module "document_check_function" {
   back_office_documents_system_topic_name                                             = var.back_office_documents_system_topic_name
   service_bus_namespace_name                                                          = var.service_bus_namespace_name
   deadline_submissions_topic_name                                                     = var.deadline_submissions_topic_name
+  document_storage_account_name                                                       = var.document_storage_account_name
 
   providers = {
     azurerm         = azurerm

--- a/app/components/back-office-app-services/document-check-function/function-app.tf
+++ b/app/components/back-office-app-services/document-check-function/function-app.tf
@@ -19,11 +19,12 @@ module "anti_virus_functions" {
   function_node_version = 14
 
   app_settings = {
-    CLAM_AV_HOST      = var.clamav_host
-    CLAM_AV_PORT      = "3310"
-    API_HOST          = var.back_office_api_host
-    SERVICE_BUS_HOST  = "${var.service_bus_namespace_name}.servicebus.windows.net"
-    SERVICE_BUS_TOPIC = var.deadline_submissions_topic_name
+    CLAM_AV_HOST              = var.clamav_host
+    CLAM_AV_PORT              = "3310"
+    API_HOST                  = var.back_office_api_host
+    SERVICE_BUS_HOST          = "${var.service_bus_namespace_name}.servicebus.windows.net"
+    SERVICE_BUS_TOPIC         = var.deadline_submissions_topic_name
+    EXCLUDED_STORAGE_ACCOUNTS = jsonencode([var.document_storage_account_name])
   }
 
   tags = var.tags

--- a/app/components/back-office-app-services/document-check-function/variables.tf
+++ b/app/components/back-office-app-services/document-check-function/variables.tf
@@ -88,3 +88,8 @@ variable "deadline_submissions_topic_name" {
   description = "Deadline Submissions Topic Name"
   type        = string
 }
+
+variable "document_storage_account_name" {
+  description = "Document Storage Account name"
+  type        = string
+}


### PR DESCRIPTION
Microsoft Defender will now handle malware scanning for this account.

# Pull Request Template

## Describe your changes

Set an environment variable on the document check function to disable it for the storage account now being handled by Microsoft Defender.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
