### PR TITLE
fix: Add waf exclusions for false positive Applications blocks

### DIFF
--- a/app/stacks/global/front-door/waf-policy.tf
+++ b/app/stacks/global/front-door/waf-policy.tf
@@ -110,6 +110,26 @@ resource "azurerm_frontdoor_firewall_policy" "default" {
           selector       = "code"
         }
       }
+
+      rule {
+        # SQL Hex Encoding Identified
+        rule_id = "942450"
+        action  = "Block"
+
+        exclusion {
+          # Exclusion to allow cookie connect.sid
+          match_variable = "RequestCookieNames" # "CookieValue:connect.sid"
+          operator       = "Equals"
+          selector       = "connect.sid"
+        }
+      }
+    }
+
+    # Exception for ASB-2059 - Exclude all rules for this selector.
+    exclusion {
+      match_variable = "RequestBodyPostArgNames"
+      operator       = "Equals"
+      selector       = "comment"
     }
 
     # Exception for ASB-1692 merged with ASB-1928 - Exclude all rules for this selector.


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

[Issue ticket number and link](https://pins-ds.atlassian.net/browse/ASB-2070)
https://pins-ds.atlassian.net/browse/ASB-2059

Add WAF exclusions for applications session.sid which is blocking users for hex encoding however there are often hex chars 
in the session sid which is blocking quite a few users from accessing the site.

Also exclude all blocks for submitting comments, we currently have a service worker to capture this data, however where users have disabled javascript they are unable to get past the WAF block.  This is only for the 'comment' past fields in the applications service registrations and submission forms.


## Useful information to review or test


1) For the comment issue, turn off javascript and post comment value:
s:gXjqsCkvGr9FQ9JlxsMAaoD9ufqJ7SfX.dV0X8a5koWbp2HIUEx7v5sBC50/JTg1aFU5lCebDldo

2) For the session block:
Open Chrome browser Developer Tools, go to Application, then Cookies

For cookie connect.sid, change value to s:gXjqsCkvGr9FQ9JlxsMAaoD9ufqJ7SfX.dV0X8a5koWbp2HIUEx7v5sBC50/JTg1aFU5lCebDldo

Refresh the website, you should see “Request is blocked” error


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
