### PR TITLE
Comment out network_rules block from new storage accounts in back-office

### DIFF
--- a/app/stacks/uk-south/back-office/database.tf
+++ b/app/stacks/uk-south/back-office/database.tf
@@ -68,6 +68,8 @@ resource "azurerm_storage_account" "back_office_sql_server" {
   #TODO: Logging
   #checkov:skip=CKV_AZURE_33: Not using queues, could implement example commented out
   #checkov:skip=CKV2_AZURE_21: Logging not implemented yet
+  #TODO: Access restrictions
+  #checkov:skip=CKV_AZURE_35: Network access restrictions
 
   name                             = replace("pinsstsqlapps${local.resource_suffix}", "-", "")
   resource_group_name              = azurerm_resource_group.back_office_stack.name
@@ -79,12 +81,12 @@ resource "azurerm_storage_account" "back_office_sql_server" {
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
 
-  network_rules {
-    default_action             = "Deny"
-    ip_rules                   = ["127.0.0.1"]
-    virtual_network_subnet_ids = [azurerm_subnet.back_office_ingress.id]
-    bypass                     = ["AzureServices"]
-  }
+  # network_rules {
+  #   default_action             = "Deny"
+  #   ip_rules                   = ["127.0.0.1"]
+  #   virtual_network_subnet_ids = [azurerm_subnet.back_office_ingress.id]
+  #   bypass                     = ["AzureServices"]
+  # }
 
   identity {
     type = "SystemAssigned"

--- a/app/stacks/uk-west/back-office/database.tf
+++ b/app/stacks/uk-west/back-office/database.tf
@@ -133,6 +133,8 @@ resource "azurerm_storage_account" "back_office_sql_server" {
   #TODO: Logging
   #checkov:skip=CKV_AZURE_33: Not using queues, could implement example commented out
   #checkov:skip=CKV2_AZURE_21: Logging not implemented yet
+  #TODO: Access restrictions
+  #checkov:skip=CKV_AZURE_35: Network access restrictions
 
   name                             = replace("pinsstsqlapps${local.resource_suffix}", "-", "")
   resource_group_name              = azurerm_resource_group.back_office_stack.name
@@ -144,12 +146,12 @@ resource "azurerm_storage_account" "back_office_sql_server" {
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
 
-  network_rules {
-    default_action             = "Deny"
-    ip_rules                   = ["127.0.0.1"]
-    virtual_network_subnet_ids = [azurerm_subnet.back_office_ingress.id]
-    bypass                     = ["AzureServices"]
-  }
+  # network_rules {
+  #   default_action             = "Deny"
+  #   ip_rules                   = ["127.0.0.1"]
+  #   virtual_network_subnet_ids = [azurerm_subnet.back_office_ingress.id]
+  #   bypass                     = ["AzureServices"]
+  # }
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
This seems to be preventing the storage account from being created.

# Pull Request Template

## Describe your changes

* Comment out network_rules block from new storage accounts in back-office
This seems to be preventing the storage account from being created.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
