### PR TITLE
chore: add key vault flag for back office functions

### DIFF
--- a/app/components/back-office-app-services/applications-migration-function/function-app.tf
+++ b/app/components/back-office-app-services/applications-migration-function/function-app.tf
@@ -21,9 +21,10 @@ module "applications_migration_function" {
 
   app_settings = {
     # Function env variables
-    API_HOST      = var.back_office_api_host
-    KEY_VAULT_URI = var.key_vault_uri
-    NODE_ENV      = var.node_environment
+    API_HOST          = var.back_office_api_host
+    KEY_VAULT_ENABLED = var.api_key_vault_authorization_enabled
+    KEY_VAULT_URI     = var.key_vault_uri
+    NODE_ENV          = var.node_environment
     # Temporary migration variables for Project Updates
     NI_DB_MYSQL_DATABASE = local.secret_refs["applications-service-mysql-database"]
     NI_DB_MYSQL_DIALECT  = local.secret_refs["applications-service-mysql-dialect"]

--- a/app/components/back-office-app-services/applications-migration-function/variables.tf
+++ b/app/components/back-office-app-services/applications-migration-function/variables.tf
@@ -9,6 +9,11 @@ variable "action_group_ids" {
   })
 }
 
+variable "api_key_vault_authorization_enabled" {
+  description = "Whether or not Key Vault is used to access secrets from the app"
+  type        = string
+}
+
 variable "back_office_api_host" {
   description = "Back Office Api Host"
   type        = string

--- a/app/components/back-office-app-services/func-applications-migration.tf
+++ b/app/components/back-office-app-services/func-applications-migration.tf
@@ -13,6 +13,7 @@ module "applications_migration_function" {
   function_apps_storage_account            = var.document_check_function_storage_name
   function_apps_storage_account_access_key = var.document_check_function_storage_primary_access_key
   app_service_plan_id                      = azurerm_service_plan.back_office_functions_plan.id
+  api_key_vault_authorization_enabled      = var.api_key_vault_authorization_enabled
   key_vault_uri                            = var.key_vault_uri
   key_vault_id                             = var.key_vault_id
   node_environment                         = var.node_environment


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Add `KEY_VAULT_ENABLED` feature flag to back office migration function app

value to be passed to [addAuthHeadersForBackend](https://github.com/Planning-Inspectorate/back-office/blob/3fffc7d4643742fcc7174d88bb5124a1475d6555/apps/functions/applications-migration/common/back-office-api-client.js#L27) function to allow api key requirement to be disabled when running function locally

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
