### PR TITLE
fix(applications): Add subscription filter to documents for Publish

### DIFF
--- a/app/components/applications-app-services/function-app.tf
+++ b/app/components/applications-app-services/function-app.tf
@@ -108,6 +108,19 @@ resource "azurerm_role_assignment" "nsip_document_service_bus_role" {
   principal_id         = module.back_office_subscribers[0].principal_id
 }
 
+resource "azurerm_servicebus_subscription_rule" "nsip_document_topic_subscription_rule" {
+  count = var.feature_back_office_subscriber_enabled ? 1 : 0
+
+  name            = "applications-nsip-document-subscription-rule"
+  subscription_id = azurerm_servicebus_subscription.nsip_document_topic_subscription[0].id
+  filter_type     = "CorrelationFilter"
+  correlation_filter {
+    properties = {
+      type = "Publish"
+    }
+  }
+}
+
 # nsip-document-unpublish
 resource "azurerm_servicebus_subscription" "nsip_document_unpublish_topic_subscription" {
   count = var.feature_back_office_subscriber_enabled ? 1 : 0


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Applications documents subscription requires a correlation filter to only consume messages of type "Published".
An issue has been observed in test where newly created documents are appearing in Applications Front office.


[Issue ticket number and link](https://pins-ds.atlassian.net/browse/ASB-2322)

## Useful information to review or test


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
