### PR TITLE
Remove back_office_feature_flags variable and hard-coding of flags

### DIFF
--- a/app/stacks/uk-west/back-office/README.md
+++ b/app/stacks/uk-west/back-office/README.md
@@ -33,7 +33,6 @@ This component contains the infrastructure required for the back office service.
 |------|------|
 | [azurerm_advanced_threat_protection.back_office_sql_server](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/advanced_threat_protection) | resource |
 | [azurerm_app_configuration.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/app_configuration) | resource |
-| [azurerm_app_configuration_feature.back_office](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/app_configuration_feature) | resource |
 | [azurerm_application_insights.back_office_app_insights](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/application_insights) | resource |
 | [azurerm_application_insights.back_office_appeals_insights](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/application_insights) | resource |
 | [azurerm_eventgrid_system_topic.back_office_documents_system_topic](https://registry.terraform.io/providers/hashicorp/azurerm/3.74.0/docs/resources/eventgrid_system_topic) | resource |
@@ -157,7 +156,6 @@ This component contains the infrastructure required for the back office service.
 | <a name="input_back_office_applications_log_level_file"></a> [back\_office\_applications\_log\_level\_file](#input\_back\_office\_applications\_log\_level\_file) | Log level for the server.log file - trace, debug, info, warn, error, fatal, silent | `string` | n/a | yes |
 | <a name="input_back_office_applications_log_level_stdout"></a> [back\_office\_applications\_log\_level\_stdout](#input\_back\_office\_applications\_log\_level\_stdout) | Log level for stdout - trace, debug, info, warn, error, fatal, silent | `string` | n/a | yes |
 | <a name="input_back_office_clamav_subnet_id"></a> [back\_office\_clamav\_subnet\_id](#input\_back\_office\_clamav\_subnet\_id) | Integration subnet for the clamav container | `string` | n/a | yes |
-| <a name="input_back_office_feature_flags"></a> [back\_office\_feature\_flags](#input\_back\_office\_feature\_flags) | A list of maps describing feature flags to be saved in the App Configuration store | `list(any)` | n/a | yes |
 | <a name="input_back_office_integration_subnet_id"></a> [back\_office\_integration\_subnet\_id](#input\_back\_office\_integration\_subnet\_id) | Integration subnet for back office anti-virus resources | `string` | n/a | yes |
 | <a name="input_back_office_public_url"></a> [back\_office\_public\_url](#input\_back\_office\_public\_url) | The public URL for the Back Office frontend web app | `string` | n/a | yes |
 | <a name="input_back_office_public_url_new"></a> [back\_office\_public\_url\_new](#input\_back\_office\_public\_url\_new) | The new public URL for the Back Office frontend web app | `string` | `null` | no |

--- a/app/stacks/uk-west/back-office/app-service-config.tf
+++ b/app/stacks/uk-west/back-office/app-service-config.tf
@@ -8,27 +8,6 @@ resource "azurerm_app_configuration" "back_office" {
   tags = local.tags
 }
 
-resource "azurerm_app_configuration_feature" "back_office" {
-  for_each = { for feature in var.back_office_feature_flags : feature.name => feature }
-
-  configuration_store_id = azurerm_app_configuration.back_office.id
-  name                   = each.value["name"]
-  description            = try(each.value["description"], null)
-  enabled                = try(each.value["enabled"], true)
-  label                  = try(each.value["label"], null)
-
-  targeting_filter {
-    default_rollout_percentage = try(each.value["targeting"]["percentage"], 100)
-    users                      = try(each.value["targeting"]["users"], [])
-  }
-
-  tags = local.tags
-
-  depends_on = [
-    azurerm_role_assignment.back_office_app_configuration_terraform
-  ]
-}
-
 resource "azurerm_private_endpoint" "back_office_app_config" {
   name                = "pins-pe-${local.service_name}-asc-${local.resource_suffix}"
   location            = azurerm_resource_group.back_office_stack.location

--- a/app/stacks/uk-west/back-office/variables.tf
+++ b/app/stacks/uk-west/back-office/variables.tf
@@ -349,8 +349,3 @@ variable "back_office_published_documents_domain" {
   description = "Domain for published documents"
   type        = string
 }
-
-variable "back_office_feature_flags" {
-  description = "A list of maps describing feature flags to be saved in the App Configuration store"
-  type        = list(any)
-}

--- a/config/variables/stacks/back-office/dev.hcl
+++ b/config/variables/stacks/back-office/dev.hcl
@@ -1,14 +1,4 @@
 locals {
-  back_office_feature_flags = [
-    {
-      name    = "boas-1-test-feature"
-      enabled = true
-      targeting = {
-        percentage = 100
-        users      = []
-      }
-    }
-  ]
   node_environment                    = "production"
   horizon_web_url                     = "" # Mocking Horizon on dev
   horizon_api_url                     = "http://10.0.7.4:8000"

--- a/config/variables/stacks/back-office/prod.hcl
+++ b/config/variables/stacks/back-office/prod.hcl
@@ -1,14 +1,4 @@
 locals {
-  back_office_feature_flags = [
-    {
-      name    = "boas-1-test-feature"
-      enabled = false
-      targeting = {
-        percentage = 100
-        users      = []
-      }
-    }
-  ]
   node_environment                    = "production"
   horizon_web_url                     = "https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId="
   horizon_api_url                     = "http://10.224.161.68:8000"

--- a/config/variables/stacks/back-office/test.hcl
+++ b/config/variables/stacks/back-office/test.hcl
@@ -1,14 +1,4 @@
 locals {
-  back_office_feature_flags = [
-    {
-      name    = "boas-1-test-feature"
-      enabled = true
-      targeting = {
-        percentage = 100
-        users      = []
-      }
-    }
-  ]
   node_environment                    = "production"
   horizon_web_url                     = "https://horizontest.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId="
   horizon_api_url                     = "http://10.0.7.4:8000"


### PR DESCRIPTION
Flags will now be managed exclusively through the Azure portal.

**I'm unsure whether feature flags manually added in the portal will persist between infra deployments. Will need to test that.**

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My Tech Lead is aware of any infrastructure changes that will cost money
