### PR TITLE
create has and s78 appeal form v2 feature flags

### DIFF
--- a/config/variables/stacks/appeals-service/dev.hcl
+++ b/config/variables/stacks/appeals-service/dev.hcl
@@ -33,6 +33,14 @@ locals {
       }
     },
     {
+      name    = "has-appeal-form-v2"
+      enabled = true
+      targeting = {
+        percentage = 100
+        users      = ["Q9999"]
+      }
+    },
+    {
       name    = "has-questionnaire"
       enabled = true
       targeting = {
@@ -78,6 +86,14 @@ locals {
       targeting = {
         percentage = 100
         users      = []
+      }
+    },
+    {
+      name    = "s78-appeal-form-v2"
+      enabled = true
+      targeting = {
+        percentage = 100
+        users      = ["Q9999"]
       }
     }
   ]

--- a/config/variables/stacks/appeals-service/prod.hcl
+++ b/config/variables/stacks/appeals-service/prod.hcl
@@ -33,6 +33,14 @@ locals {
       }
     },
     {
+      name    = "has-appeal-form-v2"
+      enabled = false
+      targeting = {
+        percentage = 100
+        users      = ["Q9999"]
+      }
+    },
+    {
       name    = "has-questionnaire"
       enabled = false
       targeting = {
@@ -78,6 +86,14 @@ locals {
       targeting = {
         percentage = 100
         users      = []
+      }
+    },
+    {
+      name    = "s78-appeal-form-v2"
+      enabled = false
+      targeting = {
+        percentage = 100
+        users      = ["Q9999"]
       }
     }
   ]

--- a/config/variables/stacks/appeals-service/test.hcl
+++ b/config/variables/stacks/appeals-service/test.hcl
@@ -33,6 +33,14 @@ locals {
       }
     },
     {
+      name    = "has-appeal-form-v2"
+      enabled = true
+      targeting = {
+        percentage = 100
+        users      = ["Q9999"]
+      }
+    },
+    {
       name    = "has-questionnaire"
       enabled = true
       targeting = {
@@ -78,6 +86,14 @@ locals {
       targeting = {
         percentage = 100
         users      = []
+      }
+    },
+    {
+      name    = "s78-appeal-form-v2"
+      enabled = true
+      targeting = {
+        percentage = 100
+        users      = ["Q9999"]
       }
     }
   ]


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

AAPD-1728

Adds two new feature flags for appeals FO - 'has-appeal-form-v2' and 's78-appeal-form-v2'.  The intention is for 'has-appeal-form-v2' to replace 'appeal-form-v2' (which will be deleted at a later date).

## Useful information to review or test

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
