### PR TITLE
feat(applications/bo): add exclusions for applicant.organisationName in back office only (APPLICS-35)

### DIFF
--- a/app/stacks/global/front-door/waf-policy.tf
+++ b/app/stacks/global/front-door/waf-policy.tf
@@ -561,6 +561,16 @@ resource "azurerm_frontdoor_firewall_policy" "back_office_applications_frontend"
       selector       = "comment"
     }
 
+    # Exclusions for APPLICS-631 - Exclude all rules for this selector.
+    # POST project update content, which is a strict subset of HTML
+    # only applies Back Office, so should be removed from others with new Front Door
+    exclusion {
+      match_variable = "RequestBodyPostArgNames"
+      operator       = "Equals"
+      selector       = "applicant.organisationName"
+    }
+
+
     # Exception for ASB-1692 merged with ASB-1928 - Exclude all rules for this selector.
     # POST project update content, which is a strict subset of HTML
     # only applies Back Office, so should be removed from others with new Front Door


### PR DESCRIPTION
## Describe your changes

Add exclusions to WAF policy for applicant.organisationName

## APPLICS-35 Certain test input on Applicants organisation page is not allowed
https://pins-ds.atlassian.net/browse/APPLICS-35

## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] My code changes do not include any hardcoded secrets or passwords
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
