### PR TITLE
fix(tooling): updating node app service versions to 1.31

### DIFF
--- a/app/components/appeals-app-services/app-service.tf
+++ b/app/components/appeals-app-services/app-service.tf
@@ -2,7 +2,7 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.25"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   action_group_ids                = var.action_group_ids
   app_name                        = each.value["app_name"]

--- a/app/components/appeals-app-services/app-service.tf
+++ b/app/components/appeals-app-services/app-service.tf
@@ -2,7 +2,7 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.16"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.25"
 
   action_group_ids                = var.action_group_ids
   app_name                        = each.value["app_name"]

--- a/app/components/applications-app-services/app-service.tf
+++ b/app/components/applications-app-services/app-service.tf
@@ -2,7 +2,7 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.25"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   action_group_ids                = var.action_group_ids
   app_name                        = each.value["app_name"]

--- a/app/components/applications-app-services/app-service.tf
+++ b/app/components/applications-app-services/app-service.tf
@@ -2,7 +2,7 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.16"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.25"
 
   action_group_ids                = var.action_group_ids
   app_name                        = each.value["app_name"]

--- a/app/components/back-office-app-services/app-service.tf
+++ b/app/components/back-office-app-services/app-service.tf
@@ -2,7 +2,7 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.25"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   action_group_ids                      = each.value["action_group_ids"]
   app_name                              = each.value["app_name"]

--- a/app/components/back-office-app-services/app-service.tf
+++ b/app/components/back-office-app-services/app-service.tf
@@ -2,7 +2,7 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.16"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.25"
 
   action_group_ids                      = each.value["action_group_ids"]
   app_name                              = each.value["app_name"]


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Updating node-app-service version to 1.31. With 1.31 tag version, Continuous deployment tag is set to false which is defined in Infrastructure modules 

This change is part of removing continuous deployment from workflow

Currently version 1.16 is being used. Here is the comparison between version 1.16 and 1.31
https://github.com/Planning-Inspectorate/infrastructure-modules/compare/1.16...1.31


## Issue ticket number and link

https://pins-ds.atlassian.net/browse/DEV-273




## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
