### PR TITLE
feat(appeals): ensure horizon trigger is false in staging slot

### DIFF
--- a/app/components/appeals-app-services/README.md
+++ b/app/components/appeals-app-services/README.md
@@ -22,7 +22,7 @@ This module also contains some resources such as Service Bus and Function Apps r
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_app_service"></a> [app\_service](#module\_app\_service) | github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service | 1.16 |
+| <a name="module_app_service"></a> [app\_service](#module\_app\_service) | github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service | 1.36 |
 | <a name="module_azure_region"></a> [azure\_region](#module\_azure\_region) | claranet/regions/azurerm | 4.2.1 |
 | <a name="module_front_office_subscribers"></a> [front\_office\_subscribers](#module\_front\_office\_subscribers) | github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-function-app | 1.16 |
 

--- a/app/components/appeals-app-services/app-service.tf
+++ b/app/components/appeals-app-services/app-service.tf
@@ -2,13 +2,14 @@ module "app_service" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
   for_each = local.app_services
 
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.35"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.36"
 
   action_group_ids                = var.action_group_ids
   app_name                        = each.value["app_name"]
   app_service_plan_id             = var.app_service_plan_id
   app_service_private_dns_zone_id = can(each.value["app_service_private_dns_zone_id"]) ? each.value["app_service_private_dns_zone_id"] : null
   app_settings                    = each.value["app_settings"]
+  slot_setting_overrides          = can(each.value["slot_setting_overrides"]) ? each.value["slot_setting_overrides"] : {}
   container_registry_name         = var.container_registry_name
   container_registry_rg           = var.container_registry_rg
   endpoint_subnet_id              = can(each.value["endpoint_subnet_id"]) ? each.value["endpoint_subnet_id"] : null

--- a/app/components/appeals-app-services/locals.tf
+++ b/app/components/appeals-app-services/locals.tf
@@ -183,6 +183,10 @@ locals {
         TASK_SUBMIT_TO_HORIZON_CRON_STRING                                                    = var.task_submit_to_horizon_cron_string
         TASK_SUBMIT_TO_HORIZON_TRIGGER_ACTIVE                                                 = var.task_submit_to_horizon_trigger_active
       }
+
+      slot_setting_overrides = {
+        TASK_SUBMIT_TO_HORIZON_TRIGGER_ACTIVE = "false"
+      }
     }
 
     appeal_documents_service_api = {


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

https://pins-ds.atlassian.net/browse/A2-2010

Overrides TASK_SUBMIT_TO_HORIZON_TRIGGER_ACTIVE to always be false in the staging slot
This is so the cron job does not run twice and duplicate appeals

## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
