### PR TITLE
chore(deps): bump claranet/regions/azurerm from 4.2.1 to 8.0.2

### DIFF
--- a/app/components/appeals-app-services/region.tf
+++ b/app/components/appeals-app-services/region.tf
@@ -1,8 +1,7 @@
 module "azure_region" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible.
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/components/applications-app-services/region.tf
+++ b/app/components/applications-app-services/region.tf
@@ -1,8 +1,7 @@
 module "azure_region" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/components/back-office-app-services/region.tf
+++ b/app/components/back-office-app-services/region.tf
@@ -1,8 +1,7 @@
 module "azure_region" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/modules/front-door-premium/region.tf
+++ b/app/modules/front-door-premium/region.tf
@@ -1,7 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module
   source  = "claranet/regions/azurerm"
-  version = "5.1.0"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/modules/front-door/region.tf
+++ b/app/modules/front-door/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/global/back-office/region.tf
+++ b/app/stacks/global/back-office/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/global/front-door-premium/main.tf
+++ b/app/stacks/global/front-door-premium/main.tf
@@ -1,6 +1,6 @@
 module "azure_region_ukw" {
   source  = "claranet/regions/azurerm"
-  version = "7.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/global/front-door/region.tf
+++ b/app/stacks/global/front-door/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-south/appeals-service/region.tf
+++ b/app/stacks/uk-south/appeals-service/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-south/applications-service/region.tf
+++ b/app/stacks/uk-south/applications-service/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-south/back-office/region.tf
+++ b/app/stacks/uk-south/back-office/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-south/common/region.tf
+++ b/app/stacks/uk-south/common/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_uks" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-west/appeals-service/region.tf
+++ b/app/stacks/uk-west/appeals-service/region.tf
@@ -1,17 +1,15 @@
 module "azure_region_primary" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.primary_location
 }
 
 module "azure_region_secondary" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.secondary_location
 }

--- a/app/stacks/uk-west/applications-service/region.tf
+++ b/app/stacks/uk-west/applications-service/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_ukw" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-west/back-office/region.tf
+++ b/app/stacks/uk-west/back-office/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_ukw" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }

--- a/app/stacks/uk-west/common/region.tf
+++ b/app/stacks/uk-west/common/region.tf
@@ -1,8 +1,7 @@
 module "azure_region_ukw" {
   #checkov:skip=CKV_TF_1: Use of commit hash is not required for this module, referencing the official Hashicorp module.
-  #TODO: Upgrade to latest version when possible
   source  = "claranet/regions/azurerm"
-  version = "4.2.1"
+  version = "8.0.2"
 
   azure_region = var.location
 }


### PR DESCRIPTION
replaces the multiple related dependabot PRs