### PR TITLE
feat: ignore front-door and front-door-https stacks in non-prod environments

### DIFF
--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -71,6 +71,17 @@ extends:
                   echo "##vso[build.addbuildtag]stack=${{ parameters.stack }}"
                   echo "##vso[build.addbuildtag]region=${{ parameters.region }}"
                 displayName: Add stack & region build tag
+              # Remove front-door and front-door-https stacks from plan when running in non-production environments
+              # now covered by individual projects with front door premium
+              - script: |
+                  if [ "$(ENVIRONMENT)" != "prod" ]; then
+                    echo "Removing front-door and front-door-https stacks from plan for non-production environment"
+                    rm -rf $(System.DefaultWorkingDirectory)/app/stacks/global/front-door
+                    rm -rf $(System.DefaultWorkingDirectory)/app/stacks/global/front-door-https
+                  fi
+                displayName: 'Remove front-door classic stacks from plan'
+                env:
+                  ENVIRONMENT: $(ENVIRONMENT)
               - ${{ if eq(parameters.stack, 'all') }}:
                 - template: ${{variables['Build.SourcesDirectory']}}/steps/terragrunt_plan_all.yml@templates
                   parameters:

--- a/pipelines/infra-ci-plan.yml
+++ b/pipelines/infra-ci-plan.yml
@@ -28,6 +28,12 @@ extends:
             isDeployment: false
             timeoutInMinutes: 30
             steps:
+              # Remove front-door and front-door-https stacks from plan when running in non-production environments
+              # now covered by individual projects with front door premium
+              - script: |
+                  rm -rf $(System.DefaultWorkingDirectory)/app/stacks/global/front-door
+                  rm -rf $(System.DefaultWorkingDirectory)/app/stacks/global/front-door-https
+                displayName: 'Remove front-door classic stacks from plan'
               - template: ${{variables['Build.SourcesDirectory']}}/steps/terragrunt_plan_all.yml@templates
                 parameters:
                   artifactName: terraform-config-files


### PR DESCRIPTION
Changes to support FD Classic migration, some stacks are only needed in prod now.