### PR TITLE
feat(infrastructure): update log cap alert to use variables for limit and service name

### DIFF
--- a/app/stacks/global/front-door-premium/main.tf
+++ b/app/stacks/global/front-door-premium/main.tf
@@ -77,7 +77,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_cap" {
   count = var.environment == "prod" ? 1 : 0
 
   name         = "Log cap Alert"
-  display_name = "log Daily data limit reached"
+  display_name = "Daily logging limit (${var.log_daily_cap_gb}GB) reached for Front Door in PROD"
   description  = "Triggered when the log Data cap is reached."
 
   location            = module.azure_region_ukw.location

--- a/app/stacks/uk-west/appeals-service/monitoring.tf
+++ b/app/stacks/uk-west/appeals-service/monitoring.tf
@@ -156,7 +156,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_cap" {
   count = var.environment == "prod" ? 1 : 0
 
   name         = "Log cap Alert"
-  display_name = "log Daily data limit reached"
+  display_name = "Daily logging limit (${var.log_daily_cap_gb}GB) reached for ${local.service_name} in PROD"
   description  = "Triggered when the log Data cap is reached."
 
   location            = azurerm_resource_group.appeals_service_stack.location

--- a/app/stacks/uk-west/applications-service/monitoring.tf
+++ b/app/stacks/uk-west/applications-service/monitoring.tf
@@ -79,7 +79,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_cap" {
   count = var.environment == "prod" ? 1 : 0
 
   name         = "Log cap Alert"
-  display_name = "log Daily data limit reached"
+  display_name = "Daily logging limit (${var.log_daily_cap_gb}GB) reached for ${local.service_name} in PROD"
   description  = "Triggered when the log Data cap is reached."
 
   location            = azurerm_resource_group.applications_service_stack.location

--- a/app/stacks/uk-west/back-office/monitoring.tf
+++ b/app/stacks/uk-west/back-office/monitoring.tf
@@ -265,7 +265,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log_cap" {
   count = var.environment == "prod" ? 1 : 0
 
   name         = "Log cap Alert"
-  display_name = "log Daily data limit reached"
+  display_name = "Daily logging limit (${var.log_daily_cap_gb}GB) reached for ${local.service_name} in PROD"
   description  = "Triggered when the log Data cap is reached."
 
   location            = azurerm_resource_group.back_office_stack.location


### PR DESCRIPTION
**Describe your changes**
Updated log cap alert display_name to clearly include the service name and log limit for each service. This improves alert clarity when the log cap for the analytics workspace is reached. [PROD Only]

Ticket: https://pins-ds.atlassian.net/browse/DEV-662

