### PR TITLE
fix(infrastructure): remove attempted creation of key vault & restore…

### DIFF
--- a/app/stacks/uk-west/common/key-vault.tf
+++ b/app/stacks/uk-west/common/key-vault.tf
@@ -1,5 +1,6 @@
 resource "azurerm_key_vault" "environment_key_vault" {
-  #checkov:skip=CKV2_AZURE_32: "Ensure private endpoint is configured to key vault"
+  #checkov:skip=CKV_AZURE_109: TODO: Network ACL, currently not implemented as it blocks pipeline
+  #checkov:skip=CKV_AZURE_189: TODO: Ensure that Azure Key Vault disables public network access
   name                          = replace("pinskv${local.service_name}${local.kv_resource_suffix}", "-", "")
   location                      = azurerm_resource_group.common_infrastructure.location
   resource_group_name           = azurerm_resource_group.common_infrastructure.name
@@ -8,11 +9,11 @@ resource "azurerm_key_vault" "environment_key_vault" {
   soft_delete_retention_days    = 7
   tenant_id                     = data.azurerm_client_config.current.tenant_id
   sku_name                      = "standard"
-  public_network_access_enabled = false
+  public_network_access_enabled = true
 
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Deny"
+    default_action = "Allow"
   }
 
   tags = local.tags


### PR DESCRIPTION
We are enabling true to match the previously working config. Currently, as false and it is stopping applications from different teams being able to access the KV.
This could be down to network link not implemented correctly, or legacy access policy on this KV

The Private Endpoint was not fully implemented in the previous pipeline run after the merge. As this pipeline run into DEV shows us that it still wants to be created, but in its current state cannot due to the public access being disabled.
https://dev.azure.com/planninginspectorate/infrastructure/_build/results?buildId=180213&view=logs&j=d8c8df2e-1b9e-55db-c620-fddadb65a07b&t=4a549443-8431-5b51-710f-50c23f5bb89f&l=338 


# Pull Request Template

## Describe your changes

<!--
Issue ticket number and link

Please include a summary of the change along with any relevant context.
List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
