### PR TITLE
chore(infrastructure): adding private endpoint for back office SQL storage accounts

### DIFF
--- a/app/stacks/uk-south/back-office/data.tf
+++ b/app/stacks/uk-south/back-office/data.tf
@@ -28,6 +28,12 @@ data "azurerm_private_dns_zone" "service_bus" {
   provider = azurerm.tooling
 }
 
+data "azurerm_private_dns_zone" "storage" {
+  name = "privatelink.blob.core.windows.net"
+
+  provider = azurerm.tooling
+}
+
 data "azurerm_monitor_action_group" "bo_applications_tech" {
   resource_group_name = var.common_resource_group_name_ukw
   name                = var.action_group_names.bo_applications_tech

--- a/app/stacks/uk-south/back-office/database.tf
+++ b/app/stacks/uk-south/back-office/database.tf
@@ -85,16 +85,36 @@ resource "azurerm_storage_account" "back_office_sql_server" {
   https_traffic_only_enabled       = true
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
+  public_network_access_enabled    = false
 
-  # network_rules {
-  #   default_action             = "Deny"
-  #   ip_rules                   = ["127.0.0.1"]
-  #   virtual_network_subnet_ids = [azurerm_subnet.back_office_ingress.id]
-  #   bypass                     = ["AzureServices"]
-  # }
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+  }
 
   identity {
     type = "SystemAssigned"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_private_endpoint" "back_office_sql_storage" {
+  name                = "pins-sqlst-private-endpoint-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.back_office_stack.name
+  location            = azurerm_resource_group.back_office_stack.location
+  subnet_id           = azurerm_subnet.back_office_ingress.id
+
+  private_dns_zone_group {
+    name                 = "pins-pdns-${local.service_name}-sqlst-${var.environment}"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.storage.id]
+  }
+
+  private_service_connection {
+    name                           = "pins-psc-sqlst-${local.resource_suffix}"
+    private_connection_resource_id = azurerm_storage_account.back_office_sql_server.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
   }
 
   tags = local.tags

--- a/app/stacks/uk-south/back-office/monitoring.tf
+++ b/app/stacks/uk-south/back-office/monitoring.tf
@@ -41,7 +41,6 @@ resource "azurerm_mssql_server_vulnerability_assessment" "back_office_sql_server
   count                           = var.monitoring_alerts_enabled ? 1 : 0
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.back_office_sql_server.id
   storage_container_path          = "${azurerm_storage_account.back_office_sql_server.primary_blob_endpoint}${azurerm_storage_container.back_office_sql_server.name}/"
-  storage_account_access_key      = azurerm_storage_account.back_office_sql_server.primary_access_key
 
   recurring_scans {
     enabled                   = var.monitoring_alerts_enabled

--- a/app/stacks/uk-west/back-office/data.tf
+++ b/app/stacks/uk-west/back-office/data.tf
@@ -42,6 +42,12 @@ data "azurerm_private_dns_zone" "sql_synapse" {
   provider = azurerm.tooling
 }
 
+data "azurerm_private_dns_zone" "storage" {
+  name = "privatelink.blob.core.windows.net"
+
+  provider = azurerm.tooling
+}
+
 data "azurerm_monitor_action_group" "bo_applications_tech" {
   resource_group_name = var.common_resource_group_name
   name                = var.action_group_names.bo_applications_tech

--- a/app/stacks/uk-west/back-office/database.tf
+++ b/app/stacks/uk-west/back-office/database.tf
@@ -172,16 +172,35 @@ resource "azurerm_storage_account" "back_office_sql_server" {
   https_traffic_only_enabled       = true
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
-
-  # network_rules {
-  #   default_action             = "Deny"
-  #   ip_rules                   = ["127.0.0.1"]
-  #   virtual_network_subnet_ids = [azurerm_subnet.back_office_ingress.id]
-  #   bypass                     = ["AzureServices"]
-  # }
+  public_network_access_enabled    = false
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+  }
 
   identity {
     type = "SystemAssigned"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_private_endpoint" "back_office_sql_storage" {
+  name                = "pins-sqlst-private-endpoint-${local.service_name}-${local.resource_suffix}"
+  resource_group_name = azurerm_resource_group.back_office_stack.name
+  location            = azurerm_resource_group.back_office_stack.location
+  subnet_id           = azurerm_subnet.back_office_ingress.id
+
+  private_dns_zone_group {
+    name                 = "pins-pdns-${local.service_name}-sqlst-${var.environment}"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.storage.id]
+  }
+
+  private_service_connection {
+    name                           = "pins-psc-sqlst-${local.resource_suffix}"
+    private_connection_resource_id = azurerm_storage_account.back_office_sql_server.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
   }
 
   tags = local.tags

--- a/app/stacks/uk-west/back-office/monitoring.tf
+++ b/app/stacks/uk-west/back-office/monitoring.tf
@@ -96,7 +96,6 @@ resource "azurerm_mssql_server_vulnerability_assessment" "back_office_sql_server
   count                           = var.monitoring_alerts_enabled ? 1 : 0
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.back_office_sql_server.id
   storage_container_path          = "${azurerm_storage_account.back_office_sql_server.primary_blob_endpoint}${azurerm_storage_container.back_office_sql_server.name}/"
-  storage_account_access_key      = azurerm_storage_account.back_office_sql_server.primary_access_key
 
   recurring_scans {
     enabled                   = var.monitoring_alerts_enabled


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Adding private endpoint for SQL storage accounts - which hold audit policy, vulnerability assessment for SQL servers 

UK-South and UK-West locations

Below changes are added in this commit

- Adding a data block for blob private DNS Zone
- Setting public access as false and adding network cls to bypass Azure Services in Storage configuration
- Adding private endpoint definition
- Removing storage_account_access_key field in auditing policy, vulnerability assessment

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/DEV-669

## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
