### PR TITLE
Task/import statements for common key vault

### DIFF
--- a/app/stacks/uk-west/back-office/locals.tf
+++ b/app/stacks/uk-west/back-office/locals.tf
@@ -112,4 +112,24 @@ locals {
       "cbos",
     ]
   )
+
+  # Principal IDs of staging slot that require read secrets access to Key Vault. Linked to story DevOps Jira  #DEV-602
+  staging_slot_read_secrets_principal_ids = {
+    dev = {
+      back_office_frontend = "49d7f503-7823-485c-aeda-738c9b118585"
+      back_office_api      = "ec2d534d-6871-4454-8b2d-4a759fcc193b"
+    },
+    test = {
+      back_office_frontend = "143bf42c-efae-4812-835b-26cc4757d9b7"
+      back_office_api      = "ecf1064f-f382-4126-96c8-535e84b60cfe"
+    },
+    training = {
+      back_office_frontend = "eabeb6fa-b2e4-4d73-b682-62527b3664d2"
+      back_office_api      = "cb9dd29e-7cc3-45dc-8050-d7c0750d0cc1"
+    },
+    prod = {
+      back_office_frontend = "0a065567-b3ea-42e0-8bb4-24a67907f0c2"
+      back_office_api      = "07029e6d-afcb-47ce-8238-31e3ac976dad"
+    }
+  }
 }

--- a/app/stacks/uk-west/back-office/secrets.tf
+++ b/app/stacks/uk-west/back-office/secrets.tf
@@ -1,3 +1,9 @@
+import {
+  for_each = lookup(local.staging_slot_read_secrets_principal_ids, var.environment, {})
+  to       = module.app_services.module.app_service[each.key].azurerm_key_vault_access_policy.read_secrets_staging_slot[0]
+  id       = "${var.key_vault_id}/objectId/${each.value}"
+}
+
 resource "azurerm_key_vault_secret" "app_secret" {
   #checkov:skip=CKV_AZURE_41: TODO: Secret rotation
   #checkov:skip=CKV_AZURE_114: No need to set content type via Terraform, as secrets to be updated in Portal


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

After creating the private endpoint for the common key vault, the apply on that pipeline failed due to: 

```json
│ Error: a resource with the ID "/subscriptions/962e477c-0f3b-4372-97fc-a198a58e259e/resourceGroups/pins-rg-common-dev-ukw-001/providers/Microsoft.KeyVault/vaults/pinskvcommondevukw001/objectId/49d7f503-7823-485c-aeda-738c9b118585" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_key_vault_access_policy" for more information with module.app_services.module.app_service["back_office_frontend"].azurerm_key_vault_access_policy.read_secrets_staging_slot[0],
│ on .terraform/modules/app_services.app_service/modules/node-app-service/main.tf line 300, in resource "azurerm_key_vault_access_policy" "read_secrets_staging_slot":
│ 300: resource "azurerm_key_vault_access_policy" "read_secrets_staging_slot" {
```

This pr will fix that


## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
